### PR TITLE
cancel market

### DIFF
--- a/contracts/contracts/boxmeout/src/market.rs
+++ b/contracts/contracts/boxmeout/src/market.rs
@@ -76,6 +76,7 @@ const STATE_OPEN: u32 = 0;
 const STATE_CLOSED: u32 = 1;
 const STATE_RESOLVED: u32 = 2;
 const STATE_DISPUTED: u32 = 3;
+const STATE_CANCELLED: u32 = 4;
 
 /// Error codes following Soroban best practices
 #[contracterror]


### PR DESCRIPTION
# Implement `cancel_market()` for creator/admin

## Summary
Implements the `cancel_market()` function so creators or admins can cancel markets before resolution and refund all committed USDC to participants. Closes #64 
## Changes

### `contracts/contracts/boxmeout/src/market.rs`

- **State & storage**
  - Added `STATE_CANCELLED = 3`
  - Added `PARTICIPANTS_KEY` and `ADMIN_KEY`
  - Added `MarketError::Unauthorized`

- **Initialization**
  - Added `admin: Address` to `initialize()` (breaking change)

- **Participants tracking**
  - Append user to participants list in `commit_prediction()` for refunds on cancel

- **`cancel_market()`**
  - Requires caller to be creator or admin
  - Rejects cancel when market is `RESOLVED` or already `CANCELLED`
  - Refunds USDC to all participants (both commitments and revealed predictions)
  - Sets market state to `CANCELLED`
  - Emits `MarketCancelled` event

### `contracts/contracts/boxmeout/src/factory.rs`

- Added `get_admin()` for future use

### `contracts/BUILD.md`

- Updated `initialize()` example to include `admin_address`

## Acceptance criteria

- [x] Only creator or admin can cancel
- [x] Refund all committed USDC to participants
- [x] Transition status to `CANCELLED`
- [x] Emit `MarketCancelled` event
- [x] Block cancel on resolved markets
- [x] Unit tests

## Tests added

- `test_cancel_market_creator_refunds_participants` – creator cancels and refunds
- `test_cancel_market_admin_refunds_participants` – admin can cancel
- `test_cancel_market_unauthorized` – non-creator/non-admin fails
- `test_cancel_market_resolved_fails` – cannot cancel resolved market
- `test_cancel_market_refunds_predictions` – refunds revealed predictions

## Breaking change

`initialize()` now takes `admin` as the 4th parameter:

// Before
initialize(market_id, creator, factory, usdc_token, oracle, closing_time, resolution_time)

// After
initialize(market_id, creator, factory, admin, usdc_token, oracle, closing_time, resolution_time)
