### PR TITLE
feat: implement set_consensus_threshold for oracle (#75)

### DIFF
--- a/check-all.sh
+++ b/check-all.sh
@@ -26,6 +26,8 @@ npm run build > /dev/null 2>&1 &
 wait
 
 echo "  - Running Prisma validation..."
+# Set dummy DATABASE_URL for validation if not set
+export DATABASE_URL="${DATABASE_URL:-postgresql://postgres:password@localhost:5432/boxmeout_dev?schema=public}"
 npm run prisma:generate > /dev/null 2>&1
 npx prisma validate
 


### PR DESCRIPTION
- Add ThresholdUpdatedEvent struct for event emission
- Implement set_consensus_threshold function with:
  - Admin-only authentication
  - Validation: threshold >= 1 and <= oracle_count
  - Storage update for required_consensus
  - Event emission with old/new threshold and oracle count
- Add 10 comprehensive unit tests covering:
  - Success cases with threshold updates
  - Validation failures (zero, exceeds count)
  - Security (admin-only access)
  - Boundary values (min/max thresholds)
  - Integration with consensus checking
  - Multiple updates and edge cases
- Fix check-all.sh to set dummy DATABASE_URL for Prisma validation

Closes #75