### PR TITLE
feat: Implement USDC Withdrawal flow

### DIFF
--- a/backend/src/controllers/wallet.controller.ts
+++ b/backend/src/controllers/wallet.controller.ts
@@ -1,0 +1,57 @@
+// backend/src/controllers/wallet.controller.ts
+// Wallet controller — request/response layer for wallet operations
+
+import { Response } from 'express';
+import { AuthenticatedRequest } from '../types/auth.types.js';
+import { walletService } from '../services/wallet.service.js';
+import { ApiError } from '../middleware/error.middleware.js';
+import { logger } from '../utils/logger.js';
+
+export class WalletController {
+  /**
+   * POST /api/wallet/withdraw
+   *
+   * Body: { amount: number }
+   * Response: { success: true, data: { txHash, amountWithdrawn, newBalance } }
+   */
+  async withdraw(req: AuthenticatedRequest, res: Response): Promise<void> {
+    const userId = req.user?.userId;
+
+    if (!userId) {
+      throw new ApiError(401, 'UNAUTHORIZED', 'Authentication required');
+    }
+
+    const { amount } = req.body as { amount?: unknown };
+
+    // Validate amount type and value
+    if (amount === undefined || amount === null) {
+      throw new ApiError(400, 'MISSING_AMOUNT', 'amount is required');
+    }
+
+    const parsedAmount = Number(amount);
+    if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
+      throw new ApiError(
+        400,
+        'INVALID_AMOUNT',
+        'amount must be a positive number'
+      );
+    }
+
+    logger.info('Withdrawal request received', {
+      userId,
+      amount: parsedAmount,
+    });
+
+    const result = await walletService.withdraw({
+      userId,
+      amount: parsedAmount,
+    });
+
+    res.status(201).json({
+      success: true,
+      data: result,
+    });
+  }
+}
+
+export const walletController = new WalletController();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,7 @@ import treasuryRoutes from './routes/treasury.routes.js';
 import referralsRoutes from './routes/referrals.routes.js';
 import leaderboardRoutes from './routes/leaderboard.routes.js';
 import notificationsRoutes from './routes/notifications.routes.js';
+import walletRoutes from './routes/wallet.routes.js';
 
 // Import Redis initialization
 import {
@@ -228,6 +229,9 @@ app.use('/api/leaderboard', leaderboardRoutes);
 
 // Notification routes
 app.use('/api/notifications', notificationsRoutes);
+
+// Wallet routes (USDC withdraw)
+app.use('/api/wallet', walletRoutes);
 
 // =============================================================================
 // ERROR HANDLING - UPDATED WITH NEW ERROR HANDLER

--- a/backend/src/middleware/rateLimit.middleware.ts
+++ b/backend/src/middleware/rateLimit.middleware.ts
@@ -143,6 +143,27 @@ export const sensitiveOperationRateLimiter: RateLimiterMiddleware = rateLimit({
 });
 
 /**
+ * Rate limiter for USDC withdrawals
+ * Limits: 3 withdrawals per 24 hours per authenticated user
+ */
+export const withdrawalRateLimiter: RateLimiterMiddleware = rateLimit({
+  windowMs: 24 * 60 * 60 * 1000, // 24 hours
+  max: 3,
+  standardHeaders: true,
+  legacyHeaders: false,
+  store: createRedisStore('withdrawal'),
+  keyGenerator: (req: any) => {
+    const authReq = req as AuthenticatedRequest;
+    return `withdrawal:${authReq.user?.userId || getIpKey(req)}`;
+  },
+  validate: { ip: false },
+  message: rateLimitMessage(
+    'Withdrawal limit reached. Maximum 3 withdrawals per 24 hours.'
+  ),
+  skip: () => process.env.NODE_ENV === 'test',
+});
+
+/**
  * Create a custom rate limiter
  */
 export function createRateLimiter(options: {

--- a/backend/src/routes/wallet.routes.ts
+++ b/backend/src/routes/wallet.routes.ts
@@ -1,0 +1,116 @@
+// backend/src/routes/wallet.routes.ts
+// Wallet routes — USDC withdrawal endpoint
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { walletController } from '../controllers/wallet.controller.js';
+import { requireAuth } from '../middleware/auth.middleware.js';
+import { withdrawalRateLimiter } from '../middleware/rateLimit.middleware.js';
+import { AuthenticatedRequest } from '../types/auth.types.js';
+
+const router: Router = Router();
+
+/**
+ * @swagger
+ * /api/wallet/withdraw:
+ *   post:
+ *     summary: Withdraw USDC to connected wallet
+ *     description: >
+ *       Withdraws the specified amount of USDC from the user's platform balance
+ *       and sends it on-chain to their connected Stellar wallet address.
+ *       Rate limited to 3 withdrawals per 24 hours.
+ *     tags: [Wallet]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - amount
+ *             properties:
+ *               amount:
+ *                 type: number
+ *                 minimum: 0.0000001
+ *                 description: USDC amount to withdraw
+ *                 example: 25.50
+ *     responses:
+ *       201:
+ *         description: Withdrawal successful
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     txHash:
+ *                       type: string
+ *                       description: Stellar transaction hash
+ *                       example: "a1b2c3d4..."
+ *                     amountWithdrawn:
+ *                       type: number
+ *                       example: 25.50
+ *                     newBalance:
+ *                       type: number
+ *                       description: Updated platform USDC balance
+ *                       example: 74.50
+ *       400:
+ *         description: >
+ *           Invalid amount, insufficient balance, or no wallet connected.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: object
+ *                   properties:
+ *                     code:
+ *                       type: string
+ *                       enum:
+ *                         - INVALID_AMOUNT
+ *                         - INSUFFICIENT_BALANCE
+ *                         - WALLET_NOT_CONNECTED
+ *                     message:
+ *                       type: string
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       429:
+ *         description: Withdrawal rate limit exceeded (max 3 per 24 hours)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 error:
+ *                   type: object
+ *                   properties:
+ *                     code:
+ *                       type: string
+ *                       example: RATE_LIMITED
+ *                     message:
+ *                       type: string
+ *                       example: "Withdrawal limit reached. Maximum 3 withdrawals per 24 hours."
+ */
+router.post(
+  '/withdraw',
+  requireAuth,
+  withdrawalRateLimiter,
+  (req: Request, res: Response, next: NextFunction) => {
+    walletController.withdraw(req as AuthenticatedRequest, res).catch(next);
+  }
+);
+
+export default router;

--- a/backend/src/services/market.service.ts
+++ b/backend/src/services/market.service.ts
@@ -137,7 +137,8 @@ export class MarketService {
     } catch (error) {
       logger.error('Market creation error', { error });
       throw new Error(
-        `Failed to create market: ${error instanceof Error ? error.message : 'Unknown error'
+        `Failed to create market: ${
+          error instanceof Error ? error.message : 'Unknown error'
         }`
       );
     }

--- a/backend/src/services/wallet.service.ts
+++ b/backend/src/services/wallet.service.ts
@@ -1,0 +1,109 @@
+// backend/src/services/wallet.service.ts
+// Wallet service — handles USDC withdrawal flow
+
+import { Decimal } from '@prisma/client/runtime/library';
+import { prisma } from '../database/prisma.js';
+import { stellarService } from './stellar.service.js';
+import { ApiError } from '../middleware/error.middleware.js';
+import { logger } from '../utils/logger.js';
+
+export interface WithdrawParams {
+  userId: string;
+  amount: number; // USDC amount to withdraw
+}
+
+export interface WithdrawResult {
+  txHash: string;
+  amountWithdrawn: number;
+  newBalance: number;
+}
+
+export class WalletService {
+  /**
+   * Withdraw USDC from user's platform balance to their connected wallet.
+   *
+   * Flow:
+   * 1. Fetch user + validate wallet connected
+   * 2. Validate amount > 0 and <= usdcBalance
+   * 3. Initiate on-chain USDC transfer via stellarService
+   * 4. Debit DB balance inside a transaction after blockchain confirmation
+   * 5. Return txHash + new balance
+   */
+  async withdraw(params: WithdrawParams): Promise<WithdrawResult> {
+    const { userId, amount } = params;
+
+    // ── Validation ─────────────────────────────────────────────────────────────
+    if (!amount || amount <= 0) {
+      throw new ApiError(
+        400,
+        'INVALID_AMOUNT',
+        'Amount must be greater than 0'
+      );
+    }
+
+    // ── Load user ──────────────────────────────────────────────────────────────
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+      throw new ApiError(404, 'USER_NOT_FOUND', 'User not found');
+    }
+
+    if (!user.walletAddress) {
+      throw new ApiError(
+        400,
+        'WALLET_NOT_CONNECTED',
+        'No wallet connected to this account. Please connect a Stellar wallet first.'
+      );
+    }
+
+    // ── Balance check ──────────────────────────────────────────────────────────
+    const currentBalance = new Decimal(user.usdcBalance.toString());
+    const withdrawAmount = new Decimal(amount);
+
+    if (withdrawAmount.greaterThan(currentBalance)) {
+      throw new ApiError(
+        400,
+        'INSUFFICIENT_BALANCE',
+        `Insufficient USDC balance. Available: ${currentBalance.toFixed(2)}, Requested: ${withdrawAmount.toFixed(2)}`
+      );
+    }
+
+    logger.info('Processing USDC withdrawal', {
+      userId,
+      walletAddress: user.walletAddress,
+      amount,
+    });
+
+    // ── On-chain transfer ──────────────────────────────────────────────────────
+    const { txHash } = await stellarService.sendUsdc(
+      user.walletAddress,
+      withdrawAmount.toFixed(7), // Stellar supports up to 7 decimal places
+      `withdraw:${userId.slice(0, 8)}`
+    );
+
+    // ── Debit DB balance after confirmation ────────────────────────────────────
+    const updatedUser = await prisma.$transaction(async (tx) => {
+      return tx.user.update({
+        where: { id: userId },
+        data: {
+          usdcBalance: {
+            decrement: withdrawAmount.toNumber(),
+          },
+        },
+      });
+    });
+
+    const newBalance = new Decimal(
+      updatedUser.usdcBalance.toString()
+    ).toNumber();
+
+    logger.info('USDC withdrawal completed', { userId, txHash, newBalance });
+
+    return {
+      txHash,
+      amountWithdrawn: amount,
+      newBalance,
+    };
+  }
+}
+
+export const walletService = new WalletService();


### PR DESCRIPTION

Enables users to withdraw USDC from their platform balance to their connected Stellar wallet.

---

##  What Changed

### ➕ New Files

- `src/services/wallet.service.ts`  
  - Implements `withdraw()`  
  - Validates balance  
  - Calls Stellar service  
  - Debits database after confirmation  

- `src/controllers/wallet.controller.ts`  
  - Handles input validation  
  - Manages HTTP response layer  

- `src/routes/wallet.routes.ts`  
  - Adds `POST /api/wallet/withdraw`  
  - Includes Swagger documentation  

---

###  Modified Files

- `src/services/stellar.service.ts`  
  - Added `sendUsdc()` for on-chain USDC payments  

- `src/middleware/rateLimit.middleware.ts`  
  - Added `withdrawalRateLimiter` (max 3 withdrawals per user per 24 hours)  

- `src/index.ts`  
  - Registered `/api/wallet` route  

---

## 🌐 API

### `POST /api/wallet/withdraw`



closes #88