### PR TITLE
feat(cron): implement oracle consensus polling CRON job closes #90

### DIFF
--- a/backend/src/repositories/market.repository.ts
+++ b/backend/src/repositories/market.repository.ts
@@ -206,6 +206,13 @@ export class MarketRepository extends BaseRepository<Market> {
     });
   }
 
+  async getClosedMarketsAwaitingResolution(): Promise<Market[]> {
+    return await this.prisma.market.findMany({
+      where: { status: MarketStatus.CLOSED },
+      orderBy: { closedAt: 'asc' },
+    });
+  }
+
   async getClosingMarkets(withinHours: number = 24): Promise<Market[]> {
     const closingTime = new Date();
     closingTime.setHours(closingTime.getHours() + withinHours);

--- a/backend/src/services/cron.service.ts
+++ b/backend/src/services/cron.service.ts
@@ -1,9 +1,23 @@
 // Cron service - handles scheduled tasks
 import cron from 'node-cron';
 import { leaderboardService } from './leaderboard.service.js';
+import { MarketService } from './market.service.js';
+import { oracleService } from './blockchain/oracle.js';
+import { MarketRepository } from '../repositories/index.js';
 import { logger } from '../utils/logger.js';
 
 export class CronService {
+  private marketRepository: MarketRepository;
+  private marketService: MarketService;
+
+  constructor(
+    marketRepo?: MarketRepository,
+    marketSvc?: MarketService
+  ) {
+    this.marketRepository = marketRepo || new MarketRepository();
+    this.marketService = marketSvc || new MarketService();
+  }
+
   /**
    * Initializes all scheduled jobs
    */
@@ -23,7 +37,66 @@ export class CronService {
       await leaderboardService.calculateRanks();
     });
 
+    // Oracle Consensus Polling: Every 5 minutes
+    cron.schedule('*/5 * * * *', async () => {
+      await this.pollOracleConsensus();
+    });
+
     logger.info('Scheduled jobs initialized successfully');
+  }
+
+  /**
+   * Polls oracle contract for all CLOSED markets and resolves any that have reached consensus.
+   */
+  async pollOracleConsensus() {
+    logger.info('Running oracle consensus polling job');
+
+    let markets;
+    try {
+      markets = await this.marketRepository.getClosedMarketsAwaitingResolution();
+    } catch (error) {
+      logger.error('Oracle polling: failed to fetch closed markets', { error });
+      return;
+    }
+
+    if (markets.length === 0) {
+      logger.info('Oracle polling: no CLOSED markets awaiting resolution');
+      return;
+    }
+
+    logger.info(`Oracle polling: checking consensus for ${markets.length} market(s)`);
+
+    for (const market of markets) {
+      try {
+        const winningOutcome = await oracleService.checkConsensus(market.id);
+
+        if (winningOutcome === null) {
+          logger.info(`Oracle polling: no consensus yet for market ${market.id}`);
+          continue;
+        }
+
+        logger.info(`Oracle polling: consensus reached for market ${market.id}`, {
+          winningOutcome,
+        });
+
+        const resolved = await this.marketService.resolveMarket(
+          market.id,
+          winningOutcome,
+          'oracle-consensus'
+        );
+
+        logger.info(`Oracle polling: market ${market.id} resolved successfully`, {
+          winningOutcome,
+          resolvedAt: resolved.resolvedAt,
+        });
+      } catch (error) {
+        logger.error(`Oracle polling: failed to process market ${market.id}`, {
+          error,
+          marketId: market.id,
+        });
+        // Continue processing remaining markets
+      }
+    }
   }
 }
 

--- a/backend/tests/services/cron.service.test.ts
+++ b/backend/tests/services/cron.service.test.ts
@@ -1,0 +1,166 @@
+// backend/tests/services/cron.service.test.ts
+// Unit tests for CronService.pollOracleConsensus()
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CronService } from '../../src/services/cron.service.js';
+
+// Mock oracleService at module level
+vi.mock('../../src/services/blockchain/oracle.js', () => ({
+  oracleService: {
+    checkConsensus: vi.fn(),
+  },
+}));
+
+import { oracleService } from '../../src/services/blockchain/oracle.js';
+
+describe('CronService.pollOracleConsensus()', () => {
+  let cronService: CronService;
+  let mockMarketRepository: any;
+  let mockMarketService: any;
+
+  const closedMarket = (id: string) => ({
+    id,
+    status: 'CLOSED',
+    closedAt: new Date(),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockMarketRepository = {
+      getClosedMarketsAwaitingResolution: vi.fn(),
+    };
+
+    mockMarketService = {
+      resolveMarket: vi.fn(),
+    };
+
+    cronService = new CronService(mockMarketRepository, mockMarketService);
+  });
+
+  it('should do nothing when no CLOSED markets exist', async () => {
+    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([]);
+
+    await cronService.pollOracleConsensus();
+
+    expect(oracleService.checkConsensus).not.toHaveBeenCalled();
+    expect(mockMarketService.resolveMarket).not.toHaveBeenCalled();
+  });
+
+  it('should skip markets where oracle returns null (no consensus)', async () => {
+    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
+      closedMarket('market-abc'),
+    ]);
+    vi.mocked(oracleService.checkConsensus).mockResolvedValue(null);
+
+    await cronService.pollOracleConsensus();
+
+    expect(oracleService.checkConsensus).toHaveBeenCalledWith('market-abc');
+    expect(mockMarketService.resolveMarket).not.toHaveBeenCalled();
+  });
+
+  it('should resolve a market when oracle returns a winning outcome', async () => {
+    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
+      closedMarket('market-abc'),
+    ]);
+    vi.mocked(oracleService.checkConsensus).mockResolvedValue(1);
+    mockMarketService.resolveMarket.mockResolvedValue({
+      id: 'market-abc',
+      resolvedAt: new Date(),
+    });
+
+    await cronService.pollOracleConsensus();
+
+    expect(oracleService.checkConsensus).toHaveBeenCalledWith('market-abc');
+    expect(mockMarketService.resolveMarket).toHaveBeenCalledWith(
+      'market-abc',
+      1,
+      'oracle-consensus'
+    );
+  });
+
+  it('should resolve outcome 0 correctly (falsy but valid)', async () => {
+    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
+      closedMarket('market-xyz'),
+    ]);
+    vi.mocked(oracleService.checkConsensus).mockResolvedValue(0);
+    mockMarketService.resolveMarket.mockResolvedValue({
+      id: 'market-xyz',
+      resolvedAt: new Date(),
+    });
+
+    await cronService.pollOracleConsensus();
+
+    expect(mockMarketService.resolveMarket).toHaveBeenCalledWith(
+      'market-xyz',
+      0,
+      'oracle-consensus'
+    );
+  });
+
+  it('should process all markets and skip those without consensus', async () => {
+    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
+      closedMarket('market-1'),
+      closedMarket('market-2'),
+      closedMarket('market-3'),
+    ]);
+    vi.mocked(oracleService.checkConsensus)
+      .mockResolvedValueOnce(null)  // market-1: no consensus
+      .mockResolvedValueOnce(1)     // market-2: consensus → outcome 1
+      .mockResolvedValueOnce(0);    // market-3: consensus → outcome 0
+
+    mockMarketService.resolveMarket.mockResolvedValue({ resolvedAt: new Date() });
+
+    await cronService.pollOracleConsensus();
+
+    expect(oracleService.checkConsensus).toHaveBeenCalledTimes(3);
+    expect(mockMarketService.resolveMarket).toHaveBeenCalledTimes(2);
+    expect(mockMarketService.resolveMarket).toHaveBeenCalledWith('market-2', 1, 'oracle-consensus');
+    expect(mockMarketService.resolveMarket).toHaveBeenCalledWith('market-3', 0, 'oracle-consensus');
+  });
+
+  it('should continue processing remaining markets when one fails', async () => {
+    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
+      closedMarket('market-bad'),
+      closedMarket('market-good'),
+    ]);
+    vi.mocked(oracleService.checkConsensus)
+      .mockRejectedValueOnce(new Error('RPC timeout'))
+      .mockResolvedValueOnce(1);
+
+    mockMarketService.resolveMarket.mockResolvedValue({ resolvedAt: new Date() });
+
+    await cronService.pollOracleConsensus();
+
+    // Should not throw; should still resolve the second market
+    expect(oracleService.checkConsensus).toHaveBeenCalledTimes(2);
+    expect(mockMarketService.resolveMarket).toHaveBeenCalledTimes(1);
+    expect(mockMarketService.resolveMarket).toHaveBeenCalledWith('market-good', 1, 'oracle-consensus');
+  });
+
+  it('should return early and not call oracle if fetching markets fails', async () => {
+    mockMarketRepository.getClosedMarketsAwaitingResolution.mockRejectedValue(
+      new Error('DB connection lost')
+    );
+
+    await cronService.pollOracleConsensus();
+
+    expect(oracleService.checkConsensus).not.toHaveBeenCalled();
+    expect(mockMarketService.resolveMarket).not.toHaveBeenCalled();
+  });
+
+  it('should continue when resolveMarket throws for one market', async () => {
+    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
+      closedMarket('market-fail'),
+      closedMarket('market-ok'),
+    ]);
+    vi.mocked(oracleService.checkConsensus).mockResolvedValue(1);
+    mockMarketService.resolveMarket
+      .mockRejectedValueOnce(new Error('Settlement failed'))
+      .mockResolvedValueOnce({ resolvedAt: new Date() });
+
+    await cronService.pollOracleConsensus();
+
+    expect(mockMarketService.resolveMarket).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
- Add getClosedMarketsAwaitingResolution() to MarketRepository to query all CLOSED markets ordered by closedAt
- Add 5-minute polling job (*/5 * * * *) to CronService that calls oracleService.checkConsensus() for each CLOSED market
- Resolve markets with consensus via marketService.resolveMarket(), recording resolution source as 'oracle-consensus'
- Isolate per-market failures so one error does not halt the whole run; all errors are logged with marketId context
- Inject MarketRepository and MarketService via constructor for full testability without DB
- Add 8 unit tests covering: empty queue, no-consensus skip, outcome 0/1, mixed batches, oracle RPC failure, DB fetch failure, and mid-batch resolveMarket failure

closes #90 