### PR TITLE
feat(blockchain): implement user-signed transaction submission

### DIFF
--- a/backend/src/controllers/submit-tx.controller.ts
+++ b/backend/src/controllers/submit-tx.controller.ts
@@ -1,0 +1,67 @@
+// backend/src/controllers/submit-tx.controller.ts
+// Handles POST /api/trading/submit-tx
+
+import { Response, NextFunction } from 'express';
+import { AuthenticatedRequest } from '../types/auth.types.js';
+import { stellarService } from '../services/stellar.service.js';
+import { ApiError } from '../middleware/error.middleware.js';
+import { logger } from '../utils/logger.js';
+
+export class SubmitTxController {
+  /**
+   * POST /api/trading/submit-tx
+   *
+   * Body (validated by Zod before reaching here):
+   *   { signedXdr: string }
+   *
+   * Responses:
+   *   200 — { success: true, data: { transactionHash, status } }
+   *   400 — malformed XDR or invalid signature
+   *   502 — Stellar network / RPC unreachable
+   */
+  async submitTx(
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    const userId = req.user?.userId;
+    const userPublicKey = req.user?.publicKey;
+
+    if (!userId || !userPublicKey) {
+      res.status(401).json({
+        success: false,
+        error: { code: 'UNAUTHORIZED', message: 'Unauthorized' },
+      });
+      return;
+    }
+
+    const { signedXdr } = req.body as { signedXdr: string };
+
+    try {
+      const result = await stellarService.submitSignedTransaction(
+        signedXdr,
+        userPublicKey
+      );
+
+      res.status(200).json({
+        success: true,
+        data: {
+          transactionHash: result.txHash,
+          status: result.status,
+        },
+      });
+    } catch (err: any) {
+      const code: string = err.code ?? '';
+
+      if (code === 'INVALID_XDR' || code === 'INVALID_SIGNATURE') {
+        return next(new ApiError(400, code, err.message));
+      }
+
+      // Network / RPC failure
+      logger.error('submit-tx: network error', { userId, error: err.message });
+      return next(new ApiError(502, 'NETWORK_ERROR', err.message));
+    }
+  }
+}
+
+export const submitTxController = new SubmitTxController();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -219,6 +219,10 @@ app.use('/api/treasury', treasuryRoutes);
 // Trading routes (user-signed)
 app.use('/api', tradingRoutes);
 
+// User-signed transaction submission
+import submitTxRoutes from './routes/submit-tx.routes.js';
+app.use('/api/trading', submitTxRoutes);
+
 // TODO: Add other routes as they are implemented
 // app.use('/api/users', userRoutes);
 // app.use('/api/leaderboard', leaderboardRoutes);

--- a/backend/src/routes/submit-tx.routes.ts
+++ b/backend/src/routes/submit-tx.routes.ts
@@ -1,0 +1,72 @@
+// backend/src/routes/submit-tx.routes.ts
+// POST /api/trading/submit-tx — user-signed transaction submission
+
+import { Router } from 'express';
+import { submitTxController } from '../controllers/submit-tx.controller.js';
+import { requireAuth } from '../middleware/auth.middleware.js';
+import { tradeRateLimiter } from '../middleware/rateLimit.middleware.js';
+import { validate } from '../middleware/validation.middleware.js';
+import { submitTxBody } from '../schemas/validation.schemas.js';
+
+const router: Router = Router();
+
+/**
+ * @swagger
+ * /api/trading/submit-tx:
+ *   post:
+ *     summary: Submit a user-signed Stellar transaction
+ *     description: >
+ *       Accepts a base64-encoded signed XDR transaction, validates it is
+ *       well-formed and signed by the authenticated user, then submits it
+ *       to the Stellar network.
+ *     tags: [Trading]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - signedXdr
+ *             properties:
+ *               signedXdr:
+ *                 type: string
+ *                 description: Base64-encoded signed Stellar transaction XDR
+ *                 example: "AAAAAgAAAAA..."
+ *     responses:
+ *       200:
+ *         description: Transaction submitted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     transactionHash:
+ *                       type: string
+ *                     status:
+ *                       type: string
+ *       400:
+ *         description: Malformed XDR or invalid signature
+ *         $ref: '#/components/responses/BadRequest'
+ *       401:
+ *         $ref: '#/components/responses/Unauthorized'
+ *       502:
+ *         description: Stellar network error
+ */
+router.post(
+  '/submit-tx',
+  requireAuth,
+  tradeRateLimiter,
+  validate({ body: submitTxBody }),
+  (req, res, next) => submitTxController.submitTx(req as any, res, next)
+);
+
+export default router;

--- a/backend/src/schemas/validation.schemas.ts
+++ b/backend/src/schemas/validation.schemas.ts
@@ -267,6 +267,20 @@ export const distributeCreatorBody = z.object({
     ),
 });
 
+// --- Trading: user-signed transaction ---
+
+/**
+ * POST /api/trading/submit-tx
+ * signedXdr must be a non-empty base64 string (the Stellar SDK will reject
+ * anything that isn't valid XDR at the service layer).
+ */
+export const submitTxBody = z.object({
+  signedXdr: z
+    .string()
+    .min(1, 'signedXdr is required')
+    .regex(/^[A-Za-z0-9+/]+=*$/, 'signedXdr must be a valid base64 string'),
+});
+
 // --- Dispute schemas ---
 
 export const submitDisputeBody = z.object({
@@ -288,13 +302,17 @@ export const resolveDisputeBody = z
   })
   .refine(
     (data) => {
-      if (data.action === 'RESOLVE_NEW_OUTCOME' && data.newWinningOutcome === undefined) {
+      if (
+        data.action === 'RESOLVE_NEW_OUTCOME' &&
+        data.newWinningOutcome === undefined
+      ) {
         return false;
       }
       return true;
     },
     {
-      message: 'New winning outcome is required when action is RESOLVE_NEW_OUTCOME',
+      message:
+        'New winning outcome is required when action is RESOLVE_NEW_OUTCOME',
       path: ['newWinningOutcome'],
     }
   );

--- a/backend/src/services/stellar.service.ts
+++ b/backend/src/services/stellar.service.ts
@@ -9,6 +9,10 @@ import {
 } from '@stellar/stellar-sdk';
 import { AuthError } from '../types/auth.types.js';
 import { logger } from '../utils/logger.js';
+import {
+  userSignedTxService,
+  SubmitResult,
+} from './blockchain/user-tx.service.js';
 
 const STELLAR_HORIZON_URL =
   process.env.STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org';
@@ -221,6 +225,63 @@ export class StellarService {
    */
   looksLikePublicKey(str: string): boolean {
     return typeof str === 'string' && str.startsWith('G') && str.length === 56;
+  }
+
+  /**
+   * Validate and submit a user-signed Soroban transaction to the network.
+   *
+   * Error classification:
+   *   - Malformed XDR or invalid signature → throws XdrValidationError (maps to 400)
+   *   - Stellar network / RPC unreachable  → throws NetworkError (maps to 502)
+   *
+   * @param signedXdr   - Base64-encoded signed transaction XDR from the client
+   * @param userPublicKey - Stellar public key of the signing user
+   * @returns { transactionHash, status }
+   */
+  async submitSignedTransaction(
+    signedXdr: string,
+    userPublicKey: string
+  ): Promise<SubmitResult> {
+    // Step 1: Validate XDR is well-formed before hitting the network.
+    // decodeSignedXdr throws a plain Error with message starting "Invalid XDR"
+    // if the base64 cannot be decoded into a Transaction/FeeBumpTransaction.
+    try {
+      userSignedTxService.decodeSignedXdr(signedXdr);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Malformed XDR';
+      const e = new Error(msg) as Error & { code: string };
+      e.code = 'INVALID_XDR';
+      throw e;
+    }
+
+    // Step 2: Full validate + submit pipeline (signature check + Soroban RPC).
+    try {
+      return await userSignedTxService.validateAndSubmit(
+        signedXdr,
+        userPublicKey,
+        'submit-tx'
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+
+      // Signature mismatch is a client error (400)
+      if (msg.startsWith('INVALID_SIGNATURE')) {
+        const e = new Error(msg) as Error & { code: string };
+        e.code = 'INVALID_SIGNATURE';
+        throw e;
+      }
+
+      // Everything else is a downstream network/RPC failure (502)
+      logger.error('StellarService.submitSignedTransaction network error', {
+        userPublicKey,
+        error: msg,
+      });
+      const e = new Error(`Stellar network error: ${msg}`) as Error & {
+        code: string;
+      };
+      e.code = 'NETWORK_ERROR';
+      throw e;
+    }
   }
 }
 

--- a/backend/tests/services/stellar.submit-tx.test.ts
+++ b/backend/tests/services/stellar.submit-tx.test.ts
@@ -1,0 +1,258 @@
+// backend/tests/services/stellar.submit-tx.test.ts
+// Unit tests for StellarService.submitSignedTransaction
+// and the POST /api/trading/submit-tx endpoint.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { errorHandler } from '../../src/middleware/error.middleware.js';
+import { validate } from '../../src/middleware/validation.middleware.js';
+
+// ---------------------------------------------------------------------------
+// Hoist mocks — must be declared before any import that touches these modules
+// ---------------------------------------------------------------------------
+const { mockDecodeSignedXdr, mockValidateAndSubmit, mockIsValidPublicKey } =
+  vi.hoisted(() => ({
+    mockDecodeSignedXdr: vi.fn(),
+    mockValidateAndSubmit: vi.fn(),
+    mockIsValidPublicKey: vi.fn().mockReturnValue(true),
+  }));
+
+// Mock the Soroban RPC service so no network connections are made
+vi.mock('../../src/services/blockchain/user-tx.service.js', () => ({
+  userSignedTxService: {
+    decodeSignedXdr: mockDecodeSignedXdr,
+    validateAndSubmit: mockValidateAndSubmit,
+  },
+}));
+
+// Mock Prisma so the test setup's cleanDatabase() doesn't hang
+vi.mock('../../src/database/prisma.js', () => ({
+  prisma: {
+    trade: { deleteMany: vi.fn() },
+    prediction: { deleteMany: vi.fn() },
+    share: { deleteMany: vi.fn() },
+    dispute: { deleteMany: vi.fn() },
+    market: { deleteMany: vi.fn() },
+    achievement: { deleteMany: vi.fn() },
+    leaderboard: { deleteMany: vi.fn() },
+    referral: { deleteMany: vi.fn() },
+    refreshToken: { deleteMany: vi.fn() },
+    transaction: { deleteMany: vi.fn() },
+    distribution: { deleteMany: vi.fn() },
+    auditLog: { deleteMany: vi.fn() },
+    user: { deleteMany: vi.fn() },
+    $disconnect: vi.fn(),
+  },
+}));
+
+// Mock the Stellar SDK to avoid Horizon.Server construction on import
+vi.mock('@stellar/stellar-sdk', async () => {
+  const actual = await vi.importActual<any>('@stellar/stellar-sdk');
+  return {
+    ...actual,
+    Horizon: {
+      Server: vi.fn().mockImplementation(() => ({})),
+    },
+    rpc: {
+      Server: vi.fn().mockImplementation(() => ({})),
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+import { StellarService } from '../../src/services/stellar.service.js';
+import { submitTxController } from '../../src/controllers/submit-tx.controller.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Valid base64 string — content is irrelevant; XDR decode is mocked
+const VALID_B64 =
+  'AAAAAgAAAABiZmFrZXhkcmJhc2U2NGVuY29kZWRzdHJpbmcAAAAAAAAAAAAAAAA=';
+
+const AUTHED_USER = {
+  userId: 'user-1',
+  publicKey: 'GAMCVGJFOWWCF6N7YSS66DEZQSCGWZU2SCOWIA2NTMCKTODDTPUOOYDY',
+};
+
+// Inline submitTxBody schema so we don't import validation.schemas (which
+// imports stellarService singleton and triggers Stellar SDK at module load).
+import { z } from 'zod';
+const submitTxBody = z.object({
+  signedXdr: z
+    .string()
+    .min(1, 'signedXdr is required')
+    .regex(/^[A-Za-z0-9+/]+=*$/, 'signedXdr must be a valid base64 string'),
+});
+
+/**
+ * Minimal Express app — wires controller + validation without importing
+ * rateLimit.middleware (which pulls in Redis and hangs unit tests).
+ */
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+
+  // Simulate requireAuth
+  app.use((req: any, _res: any, next: any) => {
+    req.user = AUTHED_USER;
+    next();
+  });
+
+  app.post(
+    '/api/trading/submit-tx',
+    validate({ body: submitTxBody }),
+    (req: any, res: any, next: any) =>
+      submitTxController.submitTx(req, res, next)
+  );
+
+  app.use(errorHandler);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// StellarService unit tests
+// ---------------------------------------------------------------------------
+describe('StellarService.submitSignedTransaction', () => {
+  let service: StellarService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new StellarService();
+  });
+
+  it('returns txHash and status on success', async () => {
+    mockDecodeSignedXdr.mockReturnValue({});
+    mockValidateAndSubmit.mockResolvedValue({
+      txHash: 'abc123',
+      status: 'SUCCESS',
+    });
+
+    const result = await service.submitSignedTransaction(
+      VALID_B64,
+      AUTHED_USER.publicKey
+    );
+
+    expect(result.txHash).toBe('abc123');
+    expect(result.status).toBe('SUCCESS');
+    expect(mockValidateAndSubmit).toHaveBeenCalledWith(
+      VALID_B64,
+      AUTHED_USER.publicKey,
+      'submit-tx'
+    );
+  });
+
+  it('throws INVALID_XDR for malformed XDR — network is never called', async () => {
+    mockDecodeSignedXdr.mockImplementation(() => {
+      throw new Error('Invalid XDR transaction: malformed');
+    });
+
+    await expect(
+      service.submitSignedTransaction('bad!!!', AUTHED_USER.publicKey)
+    ).rejects.toMatchObject({ code: 'INVALID_XDR' });
+
+    expect(mockValidateAndSubmit).not.toHaveBeenCalled();
+  });
+
+  it('throws INVALID_SIGNATURE when signature does not match', async () => {
+    mockDecodeSignedXdr.mockReturnValue({});
+    mockValidateAndSubmit.mockRejectedValue(
+      new Error(
+        'INVALID_SIGNATURE: Transaction not signed by expected public key'
+      )
+    );
+
+    await expect(
+      service.submitSignedTransaction(VALID_B64, AUTHED_USER.publicKey)
+    ).rejects.toMatchObject({ code: 'INVALID_SIGNATURE' });
+  });
+
+  it('throws NETWORK_ERROR when Stellar RPC is unreachable', async () => {
+    mockDecodeSignedXdr.mockReturnValue({});
+    mockValidateAndSubmit.mockRejectedValue(
+      new Error('fetch failed: ECONNREFUSED')
+    );
+
+    await expect(
+      service.submitSignedTransaction(VALID_B64, AUTHED_USER.publicKey)
+    ).rejects.toMatchObject({ code: 'NETWORK_ERROR' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP endpoint tests — POST /api/trading/submit-tx
+// ---------------------------------------------------------------------------
+describe('POST /api/trading/submit-tx', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = buildApp();
+  });
+
+  it('200 — valid XDR returns transactionHash and status', async () => {
+    mockDecodeSignedXdr.mockReturnValue({});
+    mockValidateAndSubmit.mockResolvedValue({
+      txHash: 'deadbeef',
+      status: 'SUCCESS',
+    });
+
+    const res = await request(app)
+      .post('/api/trading/submit-tx')
+      .send({ signedXdr: VALID_B64 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.transactionHash).toBe('deadbeef');
+    expect(res.body.data.status).toBe('SUCCESS');
+  });
+
+  it('400 — missing signedXdr field', async () => {
+    const res = await request(app).post('/api/trading/submit-tx').send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('400 — non-base64 signedXdr rejected by Zod', async () => {
+    const res = await request(app)
+      .post('/api/trading/submit-tx')
+      .send({ signedXdr: 'not base64!!!' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('400 — malformed XDR (passes base64 check but fails decode)', async () => {
+    mockDecodeSignedXdr.mockImplementation(() => {
+      throw new Error('Invalid XDR transaction: malformed');
+    });
+
+    const res = await request(app)
+      .post('/api/trading/submit-tx')
+      .send({ signedXdr: VALID_B64 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('INVALID_XDR');
+  });
+
+  it('502 — Stellar network error', async () => {
+    mockDecodeSignedXdr.mockReturnValue({});
+    mockValidateAndSubmit.mockRejectedValue(
+      new Error('fetch failed: ECONNREFUSED')
+    );
+
+    const res = await request(app)
+      .post('/api/trading/submit-tx')
+      .send({ signedXdr: VALID_B64 });
+
+    expect(res.status).toBe(502);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('NETWORK_ERROR');
+  });
+});


### PR DESCRIPTION
Closes 386
- Add StellarService.submitSignedTransaction(signedXdr, userPublicKey) with explicit error classification: INVALID_XDR (400)  malformed base64/XDR, no network call made INVALID_SIGNATURE (400)  XDR valid but not signed by expected key NETWORK_ERROR (502)  Soroban RPC unreachable or tx rejected
- Add submitTxBody Zod schema (base64 validation) to validation.schemas.ts
- Add SubmitTxController using next(ApiError) for proper error propagation
- Add POST /api/trading/submit-tx route with requireAuth + tradeRateLimiter
- Mount route at /api/trading in index.ts
- 9 unit tests: 4 service-level + 5 HTTP endpoint (200, 400x3, 502)