### PR TITLE
feat(cron): implement scheduled market lifecycle jobs

### DIFF
--- a/backend/src/repositories/market.repository.ts
+++ b/backend/src/repositories/market.repository.ts
@@ -229,6 +229,51 @@ export class MarketRepository extends BaseRepository<Market> {
     });
   }
 
+  /**
+   * Find OPEN markets whose closingAt has already passed — ready to be closed.
+   */
+  async findExpiredOpenMarkets(): Promise<Market[]> {
+    return await this.prisma.market.findMany({
+      where: {
+        status: MarketStatus.OPEN,
+        closingAt: { lt: new Date() },
+      },
+      orderBy: { closingAt: 'asc' },
+    });
+  }
+
+  /**
+   * Find DISPUTED markets whose resolvedAt is older than windowMs milliseconds.
+   * These have passed the dispute window and can be finalized on-chain.
+   */
+  async findDisputedMarketsReadyToFinalize(
+    windowMs: number
+  ): Promise<Market[]> {
+    const cutoff = new Date(Date.now() - windowMs);
+    return await this.prisma.market.findMany({
+      where: {
+        status: MarketStatus.DISPUTED,
+        resolvedAt: { lt: cutoff },
+      },
+      orderBy: { resolvedAt: 'asc' },
+    });
+  }
+
+  /**
+   * Find RESOLVED markets that still have REVEALED (unsettled) predictions.
+   */
+  async findResolvedMarketsWithUnsettledPredictions(): Promise<Market[]> {
+    return await this.prisma.market.findMany({
+      where: {
+        status: MarketStatus.RESOLVED,
+        predictions: {
+          some: { status: 'REVEALED' },
+        },
+      },
+      orderBy: { resolvedAt: 'asc' },
+    });
+  }
+
   async getMarketStatistics() {
     const [totalMarkets, activeMarkets, totalVolume, avgParticipants] =
       await Promise.all([

--- a/backend/src/repositories/notification.repository.ts
+++ b/backend/src/repositories/notification.repository.ts
@@ -50,4 +50,17 @@ export class NotificationRepository extends BaseRepository<Notification> {
       where: { userId, isRead: false },
     });
   }
+
+  /**
+   * Delete notifications older than the given number of days.
+   * Returns the count of deleted records.
+   */
+  async deleteExpiredNotifications(olderThanDays: number): Promise<number> {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - olderThanDays);
+    const result = await this.prisma.notification.deleteMany({
+      where: { createdAt: { lt: cutoff } },
+    });
+    return result.count;
+  }
 }

--- a/backend/src/services/cron.service.ts
+++ b/backend/src/services/cron.service.ts
@@ -1,28 +1,52 @@
-// Cron service - handles scheduled tasks
+// backend/src/services/cron.service.ts
+// Scheduled background jobs for market lifecycle automation.
+
 import cron from 'node-cron';
 import { leaderboardService } from './leaderboard.service.js';
 import { MarketService } from './market.service.js';
 import { oracleService } from './blockchain/oracle.js';
+import { marketBlockchainService } from './blockchain/market.js';
 import { MarketRepository } from '../repositories/index.js';
+import { NotificationRepository } from '../repositories/notification.repository.js';
+import { PredictionRepository } from '../repositories/prediction.repository.js';
+import { PredictionStatus } from '@prisma/client';
 import { logger } from '../utils/logger.js';
+
+/** How long (ms) a DISPUTED market must sit before it is finalized on-chain. */
+const DISPUTE_WINDOW_MS = Number(
+  process.env.DISPUTE_WINDOW_MS ?? 24 * 60 * 60 * 1000 // 24 h default
+);
+
+/** Notifications older than this many days are purged. */
+const NOTIFICATION_EXPIRY_DAYS = 90;
 
 export class CronService {
   private marketRepository: MarketRepository;
   private marketService: MarketService;
+  private notificationRepository: NotificationRepository;
+  private predictionRepository: PredictionRepository;
 
-  constructor(marketRepo?: MarketRepository, marketSvc?: MarketService) {
-    this.marketRepository = marketRepo || new MarketRepository();
-    this.marketService = marketSvc || new MarketService();
+  constructor(
+    marketRepo?: MarketRepository,
+    marketSvc?: MarketService,
+    notificationRepo?: NotificationRepository,
+    predictionRepo?: PredictionRepository
+  ) {
+    this.marketRepository = marketRepo ?? new MarketRepository();
+    this.marketService = marketSvc ?? new MarketService();
+    this.notificationRepository =
+      notificationRepo ?? new NotificationRepository();
+    this.predictionRepository = predictionRepo ?? new PredictionRepository();
   }
 
-  /**
-   * Initializes all scheduled jobs
-   */
+  // ---------------------------------------------------------------------------
+  // Scheduler bootstrap
+  // ---------------------------------------------------------------------------
+
   async initialize() {
     logger.info('Initializing scheduled jobs');
 
     // Weekly Ranking Reset: Every Monday at 00:00 UTC
-    // Cron pattern: minute hour day-of-month month day-of-week
     cron.schedule('0 0 * * 1', async () => {
       logger.info('Running weekly leaderboard reset job');
       await leaderboardService.resetWeeklyRankings();
@@ -39,12 +63,240 @@ export class CronService {
       await this.pollOracleConsensus();
     });
 
+    // Close expired betting windows: Every minute
+    cron.schedule('* * * * *', async () => {
+      await this.closeBetting();
+    });
+
+    // Finalize disputed markets past their window: Every minute
+    cron.schedule('* * * * *', async () => {
+      await this.finalizeResolution();
+    });
+
+    // Settle predictions for resolved markets: Every minute
+    cron.schedule('* * * * *', async () => {
+      await this.settlePredictions();
+    });
+
+    // Expire old notifications: Daily at 03:00 UTC
+    cron.schedule('0 3 * * *', async () => {
+      await this.expireNotifications();
+    });
+
     logger.info('Scheduled jobs initialized successfully');
   }
 
-  /**
-   * Polls oracle contract for all CLOSED markets and resolves any that have reached consensus.
-   */
+  // ---------------------------------------------------------------------------
+  // Job: Close betting
+  // Every minute — find OPEN markets whose closingAt has passed; set CLOSED.
+  // ---------------------------------------------------------------------------
+
+  async closeBetting(): Promise<void> {
+    logger.info('Cron[closeBetting]: start');
+
+    let markets;
+    try {
+      markets = await this.marketRepository.findExpiredOpenMarkets();
+    } catch (error) {
+      logger.error('Cron[closeBetting]: failed to fetch expired markets', {
+        error,
+      });
+      return;
+    }
+
+    if (markets.length === 0) {
+      logger.info('Cron[closeBetting]: no expired open markets');
+      return;
+    }
+
+    logger.info(`Cron[closeBetting]: closing ${markets.length} market(s)`);
+
+    for (const market of markets) {
+      try {
+        await this.marketService.closeMarket(market.id);
+        logger.info(`Cron[closeBetting]: closed market ${market.id}`);
+      } catch (error) {
+        logger.error(
+          `Cron[closeBetting]: failed to close market ${market.id}`,
+          { error, marketId: market.id }
+        );
+        // Continue — do not let one failure block the rest
+      }
+    }
+
+    logger.info('Cron[closeBetting]: complete');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Job: Finalize resolution
+  // Every minute — find DISPUTED markets past the dispute window;
+  // call finalize_resolution on-chain then mark RESOLVED in DB.
+  // ---------------------------------------------------------------------------
+
+  async finalizeResolution(): Promise<void> {
+    logger.info('Cron[finalizeResolution]: start');
+
+    let markets;
+    try {
+      markets =
+        await this.marketRepository.findDisputedMarketsReadyToFinalize(
+          DISPUTE_WINDOW_MS
+        );
+    } catch (error) {
+      logger.error(
+        'Cron[finalizeResolution]: failed to fetch disputed markets',
+        { error }
+      );
+      return;
+    }
+
+    if (markets.length === 0) {
+      logger.info(
+        'Cron[finalizeResolution]: no disputed markets ready to finalize'
+      );
+      return;
+    }
+
+    logger.info(
+      `Cron[finalizeResolution]: finalizing ${markets.length} market(s)`
+    );
+
+    for (const market of markets) {
+      try {
+        // Call finalize_resolution on-chain (resolve_market on the contract)
+        await marketBlockchainService.resolveMarket(market.contractAddress);
+
+        // Persist the resolution in the DB — winningOutcome already set when
+        // the market was originally resolved before the dispute was raised.
+        const winningOutcome = market.winningOutcome ?? 0;
+        await this.marketService.resolveMarket(
+          market.id,
+          winningOutcome,
+          'finalize-resolution'
+        );
+
+        logger.info(`Cron[finalizeResolution]: finalized market ${market.id}`, {
+          winningOutcome,
+        });
+      } catch (error) {
+        logger.error(
+          `Cron[finalizeResolution]: failed to finalize market ${market.id}`,
+          { error, marketId: market.id }
+        );
+      }
+    }
+
+    logger.info('Cron[finalizeResolution]: complete');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Job: Settle predictions
+  // Every minute — find RESOLVED markets that still have REVEALED predictions;
+  // settle each prediction directly (idempotent — already-SETTLED rows are
+  // skipped by the REVEALED filter in the repository query).
+  // ---------------------------------------------------------------------------
+
+  async settlePredictions(): Promise<void> {
+    logger.info('Cron[settlePredictions]: start');
+
+    let markets;
+    try {
+      markets =
+        await this.marketRepository.findResolvedMarketsWithUnsettledPredictions();
+    } catch (error) {
+      logger.error(
+        'Cron[settlePredictions]: failed to fetch resolved markets',
+        { error }
+      );
+      return;
+    }
+
+    if (markets.length === 0) {
+      logger.info('Cron[settlePredictions]: no unsettled predictions found');
+      return;
+    }
+
+    logger.info(
+      `Cron[settlePredictions]: processing ${markets.length} market(s)`
+    );
+
+    for (const market of markets) {
+      if (
+        market.winningOutcome === null ||
+        market.winningOutcome === undefined
+      ) {
+        logger.warn(
+          `Cron[settlePredictions]: market ${market.id} has no winningOutcome — skipping`
+        );
+        continue;
+      }
+
+      try {
+        const predictions =
+          await this.predictionRepository.findMarketPredictions(market.id);
+
+        let settled = 0;
+        for (const prediction of predictions) {
+          if (prediction.status === PredictionStatus.SETTLED) continue;
+
+          const isWinner =
+            prediction.predictedOutcome === market.winningOutcome;
+          const pnlUsd = isWinner
+            ? Number(prediction.amountUsdc) * 0.9
+            : -Number(prediction.amountUsdc);
+
+          await this.predictionRepository.settlePrediction(
+            prediction.id,
+            isWinner,
+            pnlUsd
+          );
+          settled++;
+        }
+
+        logger.info(
+          `Cron[settlePredictions]: settled ${settled} prediction(s) for market ${market.id}`
+        );
+      } catch (error) {
+        logger.error(
+          `Cron[settlePredictions]: failed to settle predictions for market ${market.id}`,
+          { error, marketId: market.id }
+        );
+      }
+    }
+
+    logger.info('Cron[settlePredictions]: complete');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Job: Expire notifications
+  // Daily — delete notifications older than NOTIFICATION_EXPIRY_DAYS.
+  // ---------------------------------------------------------------------------
+
+  async expireNotifications(): Promise<void> {
+    logger.info('Cron[expireNotifications]: start');
+
+    try {
+      const deleted =
+        await this.notificationRepository.deleteExpiredNotifications(
+          NOTIFICATION_EXPIRY_DAYS
+        );
+      logger.info(
+        `Cron[expireNotifications]: deleted ${deleted} notification(s)`,
+        {
+          olderThanDays: NOTIFICATION_EXPIRY_DAYS,
+        }
+      );
+    } catch (error) {
+      logger.error('Cron[expireNotifications]: failed', { error });
+    }
+
+    logger.info('Cron[expireNotifications]: complete');
+  }
+
+  // ---------------------------------------------------------------------------
+  // Existing job: Oracle consensus polling
+  // ---------------------------------------------------------------------------
+
   async pollOracleConsensus() {
     logger.info('Running oracle consensus polling job');
 
@@ -79,9 +331,7 @@ export class CronService {
 
         logger.info(
           `Oracle polling: consensus reached for market ${market.id}`,
-          {
-            winningOutcome,
-          }
+          { winningOutcome }
         );
 
         const resolved = await this.marketService.resolveMarket(
@@ -92,17 +342,13 @@ export class CronService {
 
         logger.info(
           `Oracle polling: market ${market.id} resolved successfully`,
-          {
-            winningOutcome,
-            resolvedAt: resolved.resolvedAt,
-          }
+          { winningOutcome, resolvedAt: resolved.resolvedAt }
         );
       } catch (error) {
         logger.error(`Oracle polling: failed to process market ${market.id}`, {
           error,
           marketId: market.id,
         });
-        // Continue processing remaining markets
       }
     }
   }

--- a/backend/tests/services/cron.service.test.ts
+++ b/backend/tests/services/cron.service.test.ts
@@ -1,184 +1,530 @@
 // backend/tests/services/cron.service.test.ts
-// Unit tests for CronService.pollOracleConsensus()
+// Unit tests for CronService scheduled jobs.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CronService } from '../../src/services/cron.service.js';
+import { PredictionStatus } from '@prisma/client';
 
-// Mock oracleService at module level
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
 vi.mock('../../src/services/blockchain/oracle.js', () => ({
-  oracleService: {
-    checkConsensus: vi.fn(),
-  },
+  oracleService: { checkConsensus: vi.fn() },
+}));
+
+vi.mock('../../src/services/blockchain/market.js', () => ({
+  marketBlockchainService: { resolveMarket: vi.fn() },
 }));
 
 import { oracleService } from '../../src/services/blockchain/oracle.js';
+import { marketBlockchainService } from '../../src/services/blockchain/market.js';
 
-describe('CronService.pollOracleConsensus()', () => {
-  let cronService: CronService;
-  let mockMarketRepository: any;
-  let mockMarketService: any;
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
 
-  const closedMarket = (id: string) => ({
-    id,
-    status: 'CLOSED',
-    closedAt: new Date(),
+const openMarket = (id: string, closingAt = new Date(Date.now() - 1000)) => ({
+  id,
+  status: 'OPEN',
+  closingAt,
+  contractAddress: `contract-${id}`,
+  winningOutcome: null,
+});
+
+const closedMarket = (id: string) => ({
+  id,
+  status: 'CLOSED',
+  closedAt: new Date(),
+  contractAddress: `contract-${id}`,
+  winningOutcome: null,
+});
+
+const disputedMarket = (id: string, winningOutcome = 1) => ({
+  id,
+  status: 'DISPUTED',
+  resolvedAt: new Date(Date.now() - 25 * 60 * 60 * 1000), // 25 h ago
+  contractAddress: `contract-${id}`,
+  winningOutcome,
+});
+
+const resolvedMarket = (id: string, winningOutcome = 1) => ({
+  id,
+  status: 'RESOLVED',
+  resolvedAt: new Date(),
+  contractAddress: `contract-${id}`,
+  winningOutcome,
+});
+
+const revealedPrediction = (id: string, outcome: number, amount = 100) => ({
+  id,
+  userId: `user-${id}`,
+  marketId: 'market-1',
+  predictedOutcome: outcome,
+  amountUsdc: amount,
+  status: PredictionStatus.REVEALED,
+});
+
+// ---------------------------------------------------------------------------
+// Factory — builds a CronService with fully-mocked dependencies
+// ---------------------------------------------------------------------------
+
+function makeCronService() {
+  const marketRepository: any = {
+    findExpiredOpenMarkets: vi.fn(),
+    findDisputedMarketsReadyToFinalize: vi.fn(),
+    findResolvedMarketsWithUnsettledPredictions: vi.fn(),
+    getClosedMarketsAwaitingResolution: vi.fn(),
+  };
+
+  const marketService: any = {
+    closeMarket: vi.fn(),
+    resolveMarket: vi.fn(),
+  };
+
+  const notificationRepository: any = {
+    deleteExpiredNotifications: vi.fn(),
+  };
+
+  const predictionRepository: any = {
+    findMarketPredictions: vi.fn(),
+    settlePrediction: vi.fn(),
+  };
+
+  const service = new CronService(
+    marketRepository,
+    marketService,
+    notificationRepository,
+    predictionRepository
+  );
+
+  return {
+    service,
+    marketRepository,
+    marketService,
+    notificationRepository,
+    predictionRepository,
+  };
+}
+
+// ===========================================================================
+// closeBetting
+// ===========================================================================
+
+describe('CronService.closeBetting()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does nothing when no expired open markets exist', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.findExpiredOpenMarkets.mockResolvedValue([]);
+
+    await service.closeBetting();
+
+    expect(marketService.closeMarket).not.toHaveBeenCalled();
   });
 
-  beforeEach(() => {
-    vi.clearAllMocks();
+  it('closes every expired open market', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.findExpiredOpenMarkets.mockResolvedValue([
+      openMarket('m1'),
+      openMarket('m2'),
+    ]);
+    marketService.closeMarket.mockResolvedValue({});
 
-    mockMarketRepository = {
-      getClosedMarketsAwaitingResolution: vi.fn(),
-    };
+    await service.closeBetting();
 
-    mockMarketService = {
-      resolveMarket: vi.fn(),
-    };
-
-    cronService = new CronService(mockMarketRepository, mockMarketService);
+    expect(marketService.closeMarket).toHaveBeenCalledTimes(2);
+    expect(marketService.closeMarket).toHaveBeenCalledWith('m1');
+    expect(marketService.closeMarket).toHaveBeenCalledWith('m2');
   });
 
-  it('should do nothing when no CLOSED markets exist', async () => {
-    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue(
+  it('continues closing remaining markets when one fails', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.findExpiredOpenMarkets.mockResolvedValue([
+      openMarket('m-bad'),
+      openMarket('m-good'),
+    ]);
+    marketService.closeMarket
+      .mockRejectedValueOnce(new Error('DB error'))
+      .mockResolvedValueOnce({});
+
+    await service.closeBetting();
+
+    expect(marketService.closeMarket).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns early when fetching markets fails', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.findExpiredOpenMarkets.mockRejectedValue(
+      new Error('DB down')
+    );
+
+    await service.closeBetting(); // must not throw
+
+    expect(marketService.closeMarket).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// finalizeResolution
+// ===========================================================================
+
+describe('CronService.finalizeResolution()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does nothing when no disputed markets are ready', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.findDisputedMarketsReadyToFinalize.mockResolvedValue([]);
+
+    await service.finalizeResolution();
+
+    expect(marketBlockchainService.resolveMarket).not.toHaveBeenCalled();
+    expect(marketService.resolveMarket).not.toHaveBeenCalled();
+  });
+
+  it('calls on-chain resolveMarket then DB resolveMarket for each market', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    const market = disputedMarket('m1', 1);
+    marketRepository.findDisputedMarketsReadyToFinalize.mockResolvedValue([
+      market,
+    ]);
+    vi.mocked(marketBlockchainService.resolveMarket).mockResolvedValue({
+      txHash: 'tx-abc',
+    });
+    marketService.resolveMarket.mockResolvedValue({ id: 'm1' });
+
+    await service.finalizeResolution();
+
+    expect(marketBlockchainService.resolveMarket).toHaveBeenCalledWith(
+      market.contractAddress
+    );
+    expect(marketService.resolveMarket).toHaveBeenCalledWith(
+      'm1',
+      1,
+      'finalize-resolution'
+    );
+  });
+
+  it('defaults winningOutcome to 0 when null', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    const market = { ...disputedMarket('m1'), winningOutcome: null };
+    marketRepository.findDisputedMarketsReadyToFinalize.mockResolvedValue([
+      market,
+    ]);
+    vi.mocked(marketBlockchainService.resolveMarket).mockResolvedValue({
+      txHash: 'tx-abc',
+    });
+    marketService.resolveMarket.mockResolvedValue({ id: 'm1' });
+
+    await service.finalizeResolution();
+
+    expect(marketService.resolveMarket).toHaveBeenCalledWith(
+      'm1',
+      0,
+      'finalize-resolution'
+    );
+  });
+
+  it('continues when one market fails on-chain', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.findDisputedMarketsReadyToFinalize.mockResolvedValue([
+      disputedMarket('m-bad'),
+      disputedMarket('m-good'),
+    ]);
+    vi.mocked(marketBlockchainService.resolveMarket)
+      .mockRejectedValueOnce(new Error('RPC timeout'))
+      .mockResolvedValueOnce({ txHash: 'tx-ok' });
+    marketService.resolveMarket.mockResolvedValue({});
+
+    await service.finalizeResolution();
+
+    expect(marketBlockchainService.resolveMarket).toHaveBeenCalledTimes(2);
+    expect(marketService.resolveMarket).toHaveBeenCalledTimes(1);
+    expect(marketService.resolveMarket).toHaveBeenCalledWith(
+      'm-good',
+      1,
+      'finalize-resolution'
+    );
+  });
+
+  it('returns early when fetching markets fails', async () => {
+    const { service, marketRepository } = makeCronService();
+    marketRepository.findDisputedMarketsReadyToFinalize.mockRejectedValue(
+      new Error('DB down')
+    );
+
+    await service.finalizeResolution(); // must not throw
+
+    expect(marketBlockchainService.resolveMarket).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// settlePredictions
+// ===========================================================================
+
+describe('CronService.settlePredictions()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does nothing when no resolved markets have unsettled predictions', async () => {
+    const { service, marketRepository, predictionRepository } =
+      makeCronService();
+    marketRepository.findResolvedMarketsWithUnsettledPredictions.mockResolvedValue(
       []
     );
 
-    await cronService.pollOracleConsensus();
+    await service.settlePredictions();
 
-    expect(oracleService.checkConsensus).not.toHaveBeenCalled();
-    expect(mockMarketService.resolveMarket).not.toHaveBeenCalled();
+    expect(predictionRepository.findMarketPredictions).not.toHaveBeenCalled();
   });
 
-  it('should skip markets where oracle returns null (no consensus)', async () => {
-    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
+  it('settles winning and losing predictions with correct PnL', async () => {
+    const { service, marketRepository, predictionRepository } =
+      makeCronService();
+    const market = resolvedMarket('m1', 1);
+    marketRepository.findResolvedMarketsWithUnsettledPredictions.mockResolvedValue(
+      [market]
+    );
+    predictionRepository.findMarketPredictions.mockResolvedValue([
+      revealedPrediction('p1', 1, 100), // winner
+      revealedPrediction('p2', 0, 50), // loser
+    ]);
+    predictionRepository.settlePrediction.mockResolvedValue({});
+
+    await service.settlePredictions();
+
+    expect(predictionRepository.settlePrediction).toHaveBeenCalledTimes(2);
+    expect(predictionRepository.settlePrediction).toHaveBeenCalledWith(
+      'p1',
+      true,
+      90 // 100 * 0.9
+    );
+    expect(predictionRepository.settlePrediction).toHaveBeenCalledWith(
+      'p2',
+      false,
+      -50
+    );
+  });
+
+  it('skips predictions that are already SETTLED', async () => {
+    const { service, marketRepository, predictionRepository } =
+      makeCronService();
+    marketRepository.findResolvedMarketsWithUnsettledPredictions.mockResolvedValue(
+      [resolvedMarket('m1', 1)]
+    );
+    predictionRepository.findMarketPredictions.mockResolvedValue([
+      { ...revealedPrediction('p1', 1), status: PredictionStatus.SETTLED },
+    ]);
+
+    await service.settlePredictions();
+
+    expect(predictionRepository.settlePrediction).not.toHaveBeenCalled();
+  });
+
+  it('skips markets with no winningOutcome', async () => {
+    const { service, marketRepository, predictionRepository } =
+      makeCronService();
+    marketRepository.findResolvedMarketsWithUnsettledPredictions.mockResolvedValue(
+      [{ ...resolvedMarket('m1'), winningOutcome: null }]
+    );
+
+    await service.settlePredictions();
+
+    expect(predictionRepository.findMarketPredictions).not.toHaveBeenCalled();
+  });
+
+  it('continues when one market fails', async () => {
+    const { service, marketRepository, predictionRepository } =
+      makeCronService();
+    marketRepository.findResolvedMarketsWithUnsettledPredictions.mockResolvedValue(
+      [resolvedMarket('m-bad', 1), resolvedMarket('m-good', 0)]
+    );
+    predictionRepository.findMarketPredictions
+      .mockRejectedValueOnce(new Error('DB error'))
+      .mockResolvedValueOnce([revealedPrediction('p1', 0, 100)]);
+    predictionRepository.settlePrediction.mockResolvedValue({});
+
+    await service.settlePredictions();
+
+    expect(predictionRepository.settlePrediction).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns early when fetching markets fails', async () => {
+    const { service, marketRepository, predictionRepository } =
+      makeCronService();
+    marketRepository.findResolvedMarketsWithUnsettledPredictions.mockRejectedValue(
+      new Error('DB down')
+    );
+
+    await service.settlePredictions(); // must not throw
+
+    expect(predictionRepository.findMarketPredictions).not.toHaveBeenCalled();
+  });
+});
+
+// ===========================================================================
+// expireNotifications
+// ===========================================================================
+
+describe('CronService.expireNotifications()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes notifications older than 90 days and logs the count', async () => {
+    const { service, notificationRepository } = makeCronService();
+    notificationRepository.deleteExpiredNotifications.mockResolvedValue(42);
+
+    await service.expireNotifications();
+
+    expect(
+      notificationRepository.deleteExpiredNotifications
+    ).toHaveBeenCalledWith(90);
+  });
+
+  it('does not throw when deletion fails', async () => {
+    const { service, notificationRepository } = makeCronService();
+    notificationRepository.deleteExpiredNotifications.mockRejectedValue(
+      new Error('DB error')
+    );
+
+    await expect(service.expireNotifications()).resolves.not.toThrow();
+  });
+});
+
+// ===========================================================================
+// pollOracleConsensus (existing tests — preserved)
+// ===========================================================================
+
+describe('CronService.pollOracleConsensus()', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does nothing when no CLOSED markets exist', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([]);
+
+    await service.pollOracleConsensus();
+
+    expect(oracleService.checkConsensus).not.toHaveBeenCalled();
+    expect(marketService.resolveMarket).not.toHaveBeenCalled();
+  });
+
+  it('skips markets where oracle returns null (no consensus)', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
       closedMarket('market-abc'),
     ]);
     vi.mocked(oracleService.checkConsensus).mockResolvedValue(null);
 
-    await cronService.pollOracleConsensus();
+    await service.pollOracleConsensus();
 
     expect(oracleService.checkConsensus).toHaveBeenCalledWith('market-abc');
-    expect(mockMarketService.resolveMarket).not.toHaveBeenCalled();
+    expect(marketService.resolveMarket).not.toHaveBeenCalled();
   });
 
-  it('should resolve a market when oracle returns a winning outcome', async () => {
-    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
+  it('resolves a market when oracle returns a winning outcome', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
       closedMarket('market-abc'),
     ]);
     vi.mocked(oracleService.checkConsensus).mockResolvedValue(1);
-    mockMarketService.resolveMarket.mockResolvedValue({
+    marketService.resolveMarket.mockResolvedValue({
       id: 'market-abc',
       resolvedAt: new Date(),
     });
 
-    await cronService.pollOracleConsensus();
+    await service.pollOracleConsensus();
 
-    expect(oracleService.checkConsensus).toHaveBeenCalledWith('market-abc');
-    expect(mockMarketService.resolveMarket).toHaveBeenCalledWith(
+    expect(marketService.resolveMarket).toHaveBeenCalledWith(
       'market-abc',
       1,
       'oracle-consensus'
     );
   });
 
-  it('should resolve outcome 0 correctly (falsy but valid)', async () => {
-    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
+  it('resolves outcome 0 correctly (falsy but valid)', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
       closedMarket('market-xyz'),
     ]);
     vi.mocked(oracleService.checkConsensus).mockResolvedValue(0);
-    mockMarketService.resolveMarket.mockResolvedValue({
+    marketService.resolveMarket.mockResolvedValue({
       id: 'market-xyz',
       resolvedAt: new Date(),
     });
 
-    await cronService.pollOracleConsensus();
+    await service.pollOracleConsensus();
 
-    expect(mockMarketService.resolveMarket).toHaveBeenCalledWith(
+    expect(marketService.resolveMarket).toHaveBeenCalledWith(
       'market-xyz',
       0,
       'oracle-consensus'
     );
   });
 
-  it('should process all markets and skip those without consensus', async () => {
-    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
+  it('processes all markets and skips those without consensus', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
       closedMarket('market-1'),
       closedMarket('market-2'),
       closedMarket('market-3'),
     ]);
     vi.mocked(oracleService.checkConsensus)
-      .mockResolvedValueOnce(null) // market-1: no consensus
-      .mockResolvedValueOnce(1) // market-2: consensus → outcome 1
-      .mockResolvedValueOnce(0); // market-3: consensus → outcome 0
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(0);
+    marketService.resolveMarket.mockResolvedValue({ resolvedAt: new Date() });
 
-    mockMarketService.resolveMarket.mockResolvedValue({
-      resolvedAt: new Date(),
-    });
-
-    await cronService.pollOracleConsensus();
+    await service.pollOracleConsensus();
 
     expect(oracleService.checkConsensus).toHaveBeenCalledTimes(3);
-    expect(mockMarketService.resolveMarket).toHaveBeenCalledTimes(2);
-    expect(mockMarketService.resolveMarket).toHaveBeenCalledWith(
-      'market-2',
-      1,
-      'oracle-consensus'
-    );
-    expect(mockMarketService.resolveMarket).toHaveBeenCalledWith(
-      'market-3',
-      0,
-      'oracle-consensus'
-    );
+    expect(marketService.resolveMarket).toHaveBeenCalledTimes(2);
   });
 
-  it('should continue processing remaining markets when one fails', async () => {
-    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
+  it('continues processing remaining markets when one fails', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
       closedMarket('market-bad'),
       closedMarket('market-good'),
     ]);
     vi.mocked(oracleService.checkConsensus)
       .mockRejectedValueOnce(new Error('RPC timeout'))
       .mockResolvedValueOnce(1);
+    marketService.resolveMarket.mockResolvedValue({ resolvedAt: new Date() });
 
-    mockMarketService.resolveMarket.mockResolvedValue({
-      resolvedAt: new Date(),
-    });
+    await service.pollOracleConsensus();
 
-    await cronService.pollOracleConsensus();
-
-    // Should not throw; should still resolve the second market
-    expect(oracleService.checkConsensus).toHaveBeenCalledTimes(2);
-    expect(mockMarketService.resolveMarket).toHaveBeenCalledTimes(1);
-    expect(mockMarketService.resolveMarket).toHaveBeenCalledWith(
+    expect(marketService.resolveMarket).toHaveBeenCalledTimes(1);
+    expect(marketService.resolveMarket).toHaveBeenCalledWith(
       'market-good',
       1,
       'oracle-consensus'
     );
   });
 
-  it('should return early and not call oracle if fetching markets fails', async () => {
-    mockMarketRepository.getClosedMarketsAwaitingResolution.mockRejectedValue(
+  it('returns early when fetching markets fails', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.getClosedMarketsAwaitingResolution.mockRejectedValue(
       new Error('DB connection lost')
     );
 
-    await cronService.pollOracleConsensus();
+    await service.pollOracleConsensus();
 
     expect(oracleService.checkConsensus).not.toHaveBeenCalled();
-    expect(mockMarketService.resolveMarket).not.toHaveBeenCalled();
+    expect(marketService.resolveMarket).not.toHaveBeenCalled();
   });
 
-  it('should continue when resolveMarket throws for one market', async () => {
-    mockMarketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
+  it('continues when resolveMarket throws for one market', async () => {
+    const { service, marketRepository, marketService } = makeCronService();
+    marketRepository.getClosedMarketsAwaitingResolution.mockResolvedValue([
       closedMarket('market-fail'),
       closedMarket('market-ok'),
     ]);
     vi.mocked(oracleService.checkConsensus).mockResolvedValue(1);
-    mockMarketService.resolveMarket
+    marketService.resolveMarket
       .mockRejectedValueOnce(new Error('Settlement failed'))
       .mockResolvedValueOnce({ resolvedAt: new Date() });
 
-    await cronService.pollOracleConsensus();
+    await service.pollOracleConsensus();
 
-    expect(mockMarketService.resolveMarket).toHaveBeenCalledTimes(2);
+    expect(marketService.resolveMarket).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Closes #388 
- closeBetting (every minute): find OPEN markets past closingAt, set CLOSED
- finalizeResolution (every minute): find DISPUTED markets past dispute window, call finalize_resolution on-chain then persist RESOLVED in DB
- settlePredictions (every minute): find RESOLVED markets with REVEALED predictions, settle each with correct PnL (90% return for winners)
- expireNotifications (daily 03:00 UTC): delete notifications older than 90 days
- All jobs log start, completion, and per-item errors; failures are isolated so one bad market never blocks the rest of the batch
- Add MarketRepository.findExpiredOpenMarkets()
- Add MarketRepository.findDisputedMarketsReadyToFinalize(windowMs)
- Add MarketRepository.findResolvedMarketsWithUnsettledPredictions()
- Add NotificationRepository.deleteExpiredNotifications(days)
- 25 unit tests covering happy paths, error isolation, and edge cases