### PR TITLE
feat(repositories): typed RepositoryError + consistent error handling…

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4081,7 +4081,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/backend/src/repositories/base.repository.ts
+++ b/backend/src/repositories/base.repository.ts
@@ -2,6 +2,90 @@
 import { PrismaClient } from '@prisma/client';
 import { prisma } from '../database/prisma.js';
 
+// ─── Typed Repository Error ───────────────────────────────────────────────────
+
+export type RepositoryErrorCode =
+  | 'NOT_FOUND'
+  | 'UNIQUE_CONSTRAINT'
+  | 'FOREIGN_KEY_CONSTRAINT'
+  | 'QUERY_ERROR'
+  | 'UNKNOWN';
+
+export class RepositoryError extends Error {
+  constructor(
+    public readonly code: RepositoryErrorCode,
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'RepositoryError';
+  }
+}
+
+/**
+ * Maps a raw Prisma error to a typed RepositoryError.
+ * Exported so subclasses can wrap their own domain-specific Prisma calls.
+ * Uses duck-typing to avoid importing Prisma error classes directly (Prisma v5 compat).
+ */
+export function toRepositoryError(modelName: string, err: unknown): RepositoryError {
+  // PrismaClientKnownRequestError has a `code` string property
+  if (isPrismaKnownError(err)) {
+    switch (err.code) {
+      case 'P2025': // Record not found
+        return new RepositoryError(
+          'NOT_FOUND',
+          `${modelName} record not found`,
+          err
+        );
+      case 'P2002': // Unique constraint violation
+        return new RepositoryError(
+          'UNIQUE_CONSTRAINT',
+          `${modelName} unique constraint violation`,
+          err
+        );
+      case 'P2003': // Foreign key constraint violation
+        return new RepositoryError(
+          'FOREIGN_KEY_CONSTRAINT',
+          `${modelName} foreign key constraint violation`,
+          err
+        );
+      default:
+        return new RepositoryError(
+          'QUERY_ERROR',
+          `${modelName} query error: ${err.message}`,
+          err
+        );
+    }
+  }
+
+  // PrismaClientValidationError / other Prisma errors have a `message` string
+  if (err instanceof Error && err.name.startsWith('PrismaClient')) {
+    return new RepositoryError(
+      'QUERY_ERROR',
+      `${modelName} query error: ${err.message}`,
+      err
+    );
+  }
+
+  return new RepositoryError('UNKNOWN', `${modelName} unexpected error`, err);
+}
+
+/** Type guard for PrismaClientKnownRequestError (duck-typed). */
+function isPrismaKnownError(
+  err: unknown
+): err is { code: string; message: string } {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    typeof (err as any).code === 'string' &&
+    'message' in err &&
+    (err as any).constructor?.name === 'PrismaClientKnownRequestError'
+  );
+}
+
+// ─── Base Repository ──────────────────────────────────────────────────────────
+
 export abstract class BaseRepository<T> {
   protected prisma: PrismaClient;
 
@@ -9,53 +93,91 @@ export abstract class BaseRepository<T> {
     this.prisma = prismaClient || prisma;
   }
 
+  /** Return the Prisma model name (e.g. 'user', 'market'). */
   abstract getModelName(): string;
 
-  protected getModel() {
+  protected getModel(): any {
     return (this.prisma as any)[this.getModelName()];
   }
 
-  async findById(id: string): Promise<T | null> {
-    return await this.getModel().findUnique({
-      where: { id },
-    });
+  async findById(
+    id: string,
+    options?: { select?: any; include?: any }
+  ): Promise<T | null> {
+    try {
+      return await this.getModel().findUnique({
+        where: { id },
+        ...options,
+      });
+    } catch (error) {
+      throw toRepositoryError(this.getModelName(), error);
+    }
   }
 
   async findMany(options?: {
     where?: any;
+    select?: any;
     orderBy?: any;
     skip?: number;
     take?: number;
     include?: any;
   }): Promise<T[]> {
-    return await this.getModel().findMany(options);
+    try {
+      return await this.getModel().findMany(options);
+    } catch (error) {
+      throw toRepositoryError(this.getModelName(), error);
+    }
   }
 
-  async create(data: any): Promise<T> {
-    return await this.getModel().create({
-      data,
-    });
+  async create(
+    data: any,
+    options?: { select?: any; include?: any }
+  ): Promise<T> {
+    try {
+      return await this.getModel().create({ data, ...options });
+    } catch (error) {
+      throw toRepositoryError(this.getModelName(), error);
+    }
   }
 
-  async update(id: string, data: any): Promise<T> {
-    return await this.getModel().update({
-      where: { id },
-      data,
-    });
+  async update(
+    id: string,
+    data: any,
+    options?: { select?: any; include?: any }
+  ): Promise<T> {
+    try {
+      return await this.getModel().update({
+        where: { id },
+        data,
+        ...options,
+      });
+    } catch (error) {
+      throw toRepositoryError(this.getModelName(), error);
+    }
   }
 
   async delete(id: string): Promise<T> {
-    return await this.getModel().delete({
-      where: { id },
-    });
+    try {
+      return await this.getModel().delete({ where: { id } });
+    } catch (error) {
+      throw toRepositoryError(this.getModelName(), error);
+    }
   }
 
   async count(where?: any): Promise<number> {
-    return await this.getModel().count({ where });
+    try {
+      return await this.getModel().count({ where });
+    } catch (error) {
+      throw toRepositoryError(this.getModelName(), error);
+    }
   }
 
   async exists(where: any): Promise<boolean> {
-    const count = await this.getModel().count({ where });
-    return count > 0;
+    try {
+      const result = await this.getModel().count({ where });
+      return result > 0;
+    } catch (error) {
+      throw toRepositoryError(this.getModelName(), error);
+    }
   }
 }

--- a/backend/src/repositories/dispute.repository.ts
+++ b/backend/src/repositories/dispute.repository.ts
@@ -1,41 +1,46 @@
 // Dispute repository - data access layer for disputes
 import { Dispute, DisputeStatus } from '@prisma/client';
-import { BaseRepository } from './base.repository.js';
+import { BaseRepository, toRepositoryError } from './base.repository.js';
 
 export class DisputeRepository extends BaseRepository<Dispute> {
-    getModelName(): string {
-        return 'dispute';
-    }
+  getModelName(): string {
+    return 'dispute';
+  }
 
-    async findByMarketId(marketId: string): Promise<Dispute[]> {
-        return await this.prisma.dispute.findMany({
-            where: { marketId },
-            orderBy: { createdAt: 'desc' },
-        });
+  async findByMarketId(marketId: string): Promise<Dispute[]> {
+    try {
+      return await this.prisma.dispute.findMany({
+        where: { marketId },
+        orderBy: { createdAt: 'desc' },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
     }
+  }
 
-    async findByStatus(status: DisputeStatus): Promise<Dispute[]> {
-        return await this.prisma.dispute.findMany({
-            where: { status },
-            orderBy: { createdAt: 'desc' },
-        });
+  async findByStatus(status: DisputeStatus): Promise<Dispute[]> {
+    try {
+      return await this.prisma.dispute.findMany({
+        where: { status },
+        orderBy: { createdAt: 'desc' },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
     }
+  }
 
-    async updateStatus(
-        id: string,
-        status: DisputeStatus,
-        updateData?: {
-            resolution?: string;
-            adminNotes?: string;
-            resolvedAt?: Date;
-        }
-    ): Promise<Dispute> {
-        return await this.prisma.dispute.update({
-            where: { id },
-            data: {
-                status,
-                ...updateData,
-            },
-        });
+  async updateStatus(
+    id: string,
+    status: DisputeStatus,
+    updateData?: { resolution?: string; adminNotes?: string; resolvedAt?: Date }
+  ): Promise<Dispute> {
+    try {
+      return await this.prisma.dispute.update({
+        where: { id },
+        data: { status, ...updateData },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
     }
+  }
 }

--- a/backend/src/repositories/distribution.repository.ts
+++ b/backend/src/repositories/distribution.repository.ts
@@ -1,4 +1,4 @@
-import { BaseRepository } from './base.repository.js';
+import { BaseRepository, toRepositoryError } from './base.repository.js';
 import {
   Distribution,
   DistributionType,
@@ -48,9 +48,11 @@ export class DistributionRepository extends BaseRepository<Distribution> {
   }
 
   async findByTxHash(txHash: string): Promise<Distribution | null> {
-    return await this.getModel().findFirst({
-      where: { txHash },
-    });
+    try {
+      return await this.getModel().findFirst({ where: { txHash } });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async findRecent(limit: number = 20): Promise<Distribution[]> {

--- a/backend/src/repositories/index.ts
+++ b/backend/src/repositories/index.ts
@@ -1,6 +1,12 @@
 // Repository exports
-export { BaseRepository } from './base.repository.js';
+export { BaseRepository, RepositoryError } from './base.repository.js';
+export type { RepositoryErrorCode } from './base.repository.js';
 export { UserRepository } from './user.repository.js';
 export { MarketRepository } from './market.repository.js';
 export { PredictionRepository } from './prediction.repository.js';
 export { TradeRepository } from './trade.repository.js';
+export { ShareRepository, shareRepository } from './share.repository.js';
+export { NotificationRepository } from './notification.repository.js';
+export { LeaderboardRepository } from './leaderboard.repository.js';
+export { DisputeRepository } from './dispute.repository.js';
+export { DistributionRepository } from './distribution.repository.js';

--- a/backend/src/repositories/leaderboard.repository.ts
+++ b/backend/src/repositories/leaderboard.repository.ts
@@ -5,7 +5,7 @@ import {
   MarketCategory,
   StreakType,
 } from '@prisma/client';
-import { BaseRepository } from './base.repository.js';
+import { BaseRepository, toRepositoryError } from './base.repository.js';
 import { Decimal } from '@prisma/client/runtime/library';
 
 export class LeaderboardRepository extends BaseRepository<Leaderboard> {
@@ -14,188 +14,154 @@ export class LeaderboardRepository extends BaseRepository<Leaderboard> {
   }
 
   async updateUserStats(userId: string, pnl: number, isWin: boolean) {
-    const leaderboard = await this.prisma.leaderboard.findUnique({
-      where: { userId },
-    });
+    try {
+      const leaderboard = await this.prisma.leaderboard.findUnique({ where: { userId } });
 
-    if (!leaderboard) {
-      // Create initial record
-      return await this.prisma.leaderboard.create({
-        data: {
-          userId,
-          globalRank: 0,
-          weeklyRank: 0,
-          allTimePnl: pnl,
-          weeklyPnl: pnl,
-          allTimeWinRate: isWin ? 100 : 0,
-          weeklyWinRate: isWin ? 100 : 0,
-          predictionCount: 1,
-          streakLength: 1,
-          streakType: isWin ? StreakType.WIN : StreakType.LOSS,
-          lastPredictionAt: new Date(),
-        },
+      if (!leaderboard) {
+        return await this.prisma.leaderboard.create({
+          data: {
+            userId, globalRank: 0, weeklyRank: 0,
+            allTimePnl: pnl, weeklyPnl: pnl,
+            allTimeWinRate: isWin ? 100 : 0, weeklyWinRate: isWin ? 100 : 0,
+            predictionCount: 1, streakLength: 1,
+            streakType: isWin ? StreakType.WIN : StreakType.LOSS,
+            lastPredictionAt: new Date(),
+          },
+        });
+      }
+
+      const newAllTimePnl = new Decimal(leaderboard.allTimePnl.toString()).plus(pnl);
+      const newWeeklyPnl = new Decimal(leaderboard.weeklyPnl.toString()).plus(pnl);
+      const newCount = leaderboard.predictionCount + 1;
+      const currentIsWin = isWin ? StreakType.WIN : StreakType.LOSS;
+      let newStreakType = leaderboard.streakType;
+      let newStreakLength = leaderboard.streakLength;
+
+      if (currentIsWin === leaderboard.streakType) {
+        newStreakLength += 1;
+      } else {
+        newStreakType = currentIsWin;
+        newStreakLength = 1;
+      }
+
+      return await this.prisma.leaderboard.update({
+        where: { userId },
+        data: { allTimePnl: newAllTimePnl, weeklyPnl: newWeeklyPnl, predictionCount: newCount, streakLength: newStreakLength, streakType: newStreakType, lastPredictionAt: new Date() },
       });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
     }
-
-    const newAllTimePnl = new Decimal(leaderboard.allTimePnl.toString()).plus(
-      pnl
-    );
-    const newWeeklyPnl = new Decimal(leaderboard.weeklyPnl.toString()).plus(
-      pnl
-    );
-    const newCount = leaderboard.predictionCount + 1;
-
-    // Win rate calculation (simplified - we'd ideally store total wins)
-    // For now, let's assume we can derive it or track wins separately.
-    // Given the schema, we'll need to count wins from Prediction table or add a winCount field.
-    // Let's rely on the Prediction table for accurate win rate calculation during full recalculation,
-    // but update incrementally here.
-
-    let newStreakType = leaderboard.streakType;
-    let newStreakLength = leaderboard.streakLength;
-
-    const currentIsWin = isWin ? StreakType.WIN : StreakType.LOSS;
-    if (currentIsWin === leaderboard.streakType) {
-      newStreakLength += 1;
-    } else {
-      newStreakType = currentIsWin;
-      newStreakLength = 1;
-    }
-
-    return await this.prisma.leaderboard.update({
-      where: { userId },
-      data: {
-        allTimePnl: newAllTimePnl,
-        weeklyPnl: newWeeklyPnl,
-        predictionCount: newCount,
-        streakLength: newStreakLength,
-        streakType: newStreakType,
-        lastPredictionAt: new Date(),
-      },
-    });
   }
 
-  async updateCategoryStats(
-    userId: string,
-    category: MarketCategory,
-    pnl: number,
-    isWin: boolean
-  ) {
-    const stats = await this.prisma.categoryLeaderboard.findUnique({
-      where: { userId_category: { userId, category } },
-    });
+  async updateCategoryStats(userId: string, category: MarketCategory, pnl: number, isWin: boolean) {
+    try {
+      const stats = await this.prisma.categoryLeaderboard.findUnique({
+        where: { userId_category: { userId, category } },
+      });
 
-    if (!stats) {
-      return await this.prisma.categoryLeaderboard.create({
+      if (!stats) {
+        return await this.prisma.categoryLeaderboard.create({
+          data: { userId, category, totalPnl: pnl, predictionCount: 1, winRate: isWin ? 100 : 0 },
+        });
+      }
+
+      return await this.prisma.categoryLeaderboard.update({
+        where: { userId_category: { userId, category } },
         data: {
-          userId,
-          category,
-          totalPnl: pnl,
-          predictionCount: 1,
-          winRate: isWin ? 100 : 0,
+          totalPnl: new Decimal(stats.totalPnl.toString()).plus(pnl),
+          predictionCount: stats.predictionCount + 1,
         },
       });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
     }
-
-    const newPnl = new Decimal(stats.totalPnl.toString()).plus(pnl);
-    const newCount = stats.predictionCount + 1;
-
-    return await this.prisma.categoryLeaderboard.update({
-      where: { userId_category: { userId, category } },
-      data: {
-        totalPnl: newPnl,
-        predictionCount: newCount,
-      },
-    });
   }
 
   async updateAllRanks() {
-    // This uses a raw query pattern because Prisma doesn't support easy rank() window functions directly in ORM
-    // Global ranks by allTimePnl
-    await this.prisma.$executeRaw`
-      WITH Ranked AS (
-        SELECT user_id, RANK() OVER (ORDER BY all_time_pnl DESC) as new_rank
-        FROM leaderboard
-      )
-      UPDATE leaderboard
-      SET global_rank = Ranked.new_rank
-      FROM Ranked
-      WHERE leaderboard.user_id = Ranked.user_id
-    `;
-
-    // Weekly ranks by weeklyPnl
-    await this.prisma.$executeRaw`
-      WITH Ranked AS (
-        SELECT user_id, RANK() OVER (ORDER BY weekly_pnl DESC) as new_rank
-        FROM leaderboard
-      )
-      UPDATE leaderboard
-      SET weekly_rank = Ranked.new_rank
-      FROM Ranked
-      WHERE leaderboard.user_id = Ranked.user_id
-    `;
-
-    // Category ranks
-    await this.prisma.$executeRaw`
-      WITH Ranked AS (
-        SELECT user_id, category, RANK() OVER (PARTITION BY category ORDER BY total_pnl DESC) as new_rank
-        FROM category_leaderboard
-      )
-      UPDATE category_leaderboard
-      SET rank = Ranked.new_rank
-      FROM Ranked
-      WHERE category_leaderboard.user_id = Ranked.user_id 
-      AND category_leaderboard.category = Ranked.category
-    `;
+    try {
+      await this.prisma.$executeRaw`
+        WITH Ranked AS (
+          SELECT user_id, RANK() OVER (ORDER BY all_time_pnl DESC) as new_rank
+          FROM leaderboard
+        )
+        UPDATE leaderboard
+        SET global_rank = Ranked.new_rank
+        FROM Ranked
+        WHERE leaderboard.user_id = Ranked.user_id
+      `;
+      await this.prisma.$executeRaw`
+        WITH Ranked AS (
+          SELECT user_id, RANK() OVER (ORDER BY weekly_pnl DESC) as new_rank
+          FROM leaderboard
+        )
+        UPDATE leaderboard
+        SET weekly_rank = Ranked.new_rank
+        FROM Ranked
+        WHERE leaderboard.user_id = Ranked.user_id
+      `;
+      await this.prisma.$executeRaw`
+        WITH Ranked AS (
+          SELECT user_id, category, RANK() OVER (PARTITION BY category ORDER BY total_pnl DESC) as new_rank
+          FROM category_leaderboard
+        )
+        UPDATE category_leaderboard
+        SET rank = Ranked.new_rank
+        FROM Ranked
+        WHERE category_leaderboard.user_id = Ranked.user_id 
+        AND category_leaderboard.category = Ranked.category
+      `;
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async resetWeeklyStats() {
-    return await this.prisma.leaderboard.updateMany({
-      data: {
-        weeklyPnl: 0,
-        weeklyWinRate: 0,
-        weeklyRank: 0,
-      },
-    });
+    try {
+      return await this.prisma.leaderboard.updateMany({
+        data: { weeklyPnl: 0, weeklyWinRate: 0, weeklyRank: 0 },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getGlobal(limit: number, offset: number) {
-    return await this.prisma.leaderboard.findMany({
-      orderBy: { globalRank: 'asc' },
-      take: limit,
-      skip: offset,
-      include: {
-        user: {
-          select: { username: true, displayName: true, avatarUrl: true },
-        },
-      },
-    });
+    try {
+      return await this.prisma.leaderboard.findMany({
+        orderBy: { globalRank: 'asc' },
+        take: limit,
+        skip: offset,
+        include: { user: { select: { username: true, displayName: true, avatarUrl: true } } },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getWeekly(limit: number, offset: number) {
-    return await this.prisma.leaderboard.findMany({
-      orderBy: { weeklyRank: 'asc' },
-      take: limit,
-      skip: offset,
-      include: {
-        user: {
-          select: { username: true, displayName: true, avatarUrl: true },
-        },
-      },
-    });
+    try {
+      return await this.prisma.leaderboard.findMany({
+        orderBy: { weeklyRank: 'asc' },
+        take: limit,
+        skip: offset,
+        include: { user: { select: { username: true, displayName: true, avatarUrl: true } } },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getByCategory(category: MarketCategory, limit: number, offset: number) {
-    return await this.prisma.categoryLeaderboard.findMany({
-      where: { category },
-      orderBy: { rank: 'asc' },
-      take: limit,
-      skip: offset,
-      include: {
-        user: {
-          select: { username: true, displayName: true, avatarUrl: true },
-        },
-      },
-    });
+    try {
+      return await this.prisma.categoryLeaderboard.findMany({
+        where: { category },
+        orderBy: { rank: 'asc' },
+        take: limit,
+        skip: offset,
+        include: { user: { select: { username: true, displayName: true, avatarUrl: true } } },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 }

--- a/backend/src/repositories/market.repository.ts
+++ b/backend/src/repositories/market.repository.ts
@@ -1,6 +1,6 @@
 // Market repository - data access layer for markets
 import { Market, MarketStatus, MarketCategory } from '@prisma/client';
-import { BaseRepository } from './base.repository.js';
+import { BaseRepository, toRepositoryError } from './base.repository.js';
 
 export class MarketRepository extends BaseRepository<Market> {
   getModelName(): string {
@@ -8,48 +8,39 @@ export class MarketRepository extends BaseRepository<Market> {
   }
 
   async findByContractAddress(contractAddress: string): Promise<Market | null> {
-    return await this.prisma.market.findUnique({
-      where: { contractAddress },
-    });
+    try {
+      return await this.prisma.market.findUnique({ where: { contractAddress } });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
-  async addAttestation(
-    marketId: string,
-    oracleId: string,
-    outcome: number,
-    txHash: string
-  ) {
-    return await this.prisma.$transaction(async (tx) => {
-      const attestation = await tx.attestation.create({
-        data: {
-          marketId,
-          oracleId,
-          outcome,
-          txHash,
-        },
+  async addAttestation(marketId: string, oracleId: string, outcome: number, txHash: string) {
+    try {
+      return await this.prisma.$transaction(async (tx) => {
+        const attestation = await tx.attestation.create({
+          data: { marketId, oracleId, outcome, txHash },
+        });
+        const market = await tx.market.update({
+          where: { id: marketId },
+          data: { attestationCount: { increment: 1 } },
+        });
+        return { attestation, market };
       });
-
-      const market = await tx.market.update({
-        where: { id: marketId },
-        data: {
-          attestationCount: { increment: 1 },
-        },
-      });
-
-      return { attestation, market };
-    });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async hasAttested(marketId: string, oracleId: string): Promise<boolean> {
-    const record = await this.prisma.attestation.findUnique({
-      where: {
-        marketId_oracleId: {
-          marketId,
-          oracleId,
-        },
-      },
-    });
-    return !!record;
+    try {
+      const record = await this.prisma.attestation.findUnique({
+        where: { marketId_oracleId: { marketId, oracleId } },
+      });
+      return !!record;
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async createMarket(data: {
@@ -62,19 +53,16 @@ export class MarketRepository extends BaseRepository<Market> {
     outcomeB: string;
     closingAt: Date;
   }): Promise<Market> {
-    return await this.prisma.market.create({
-      data,
-      include: {
-        creator: {
-          select: {
-            id: true,
-            username: true,
-            displayName: true,
-            avatarUrl: true,
-          },
+    try {
+      return await this.prisma.market.create({
+        data,
+        include: {
+          creator: { select: { id: true, username: true, displayName: true, avatarUrl: true } },
         },
-      },
-    });
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async findActiveMarkets(options?: {
@@ -82,32 +70,34 @@ export class MarketRepository extends BaseRepository<Market> {
     skip?: number;
     take?: number;
   }): Promise<Market[]> {
-    return await this.prisma.market.findMany({
-      where: {
-        status: MarketStatus.OPEN,
-        closingAt: { gt: new Date() },
-        ...(options?.category && { category: options.category }),
-      },
-      orderBy: { closingAt: 'asc' },
-      skip: options?.skip,
-      take: options?.take || 20,
-      include: {
-        creator: {
-          select: {
-            id: true,
-            username: true,
-            displayName: true,
-          },
+    try {
+      return await this.prisma.market.findMany({
+        where: {
+          status: MarketStatus.OPEN,
+          closingAt: { gt: new Date() },
+          ...(options?.category && { category: options.category }),
         },
-      },
-    });
+        orderBy: { closingAt: 'asc' },
+        skip: options?.skip,
+        take: options?.take || 20,
+        include: {
+          creator: { select: { id: true, username: true, displayName: true } },
+        },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async findMarketsByCreator(creatorId: string): Promise<Market[]> {
-    return await this.prisma.market.findMany({
-      where: { creatorId },
-      orderBy: { createdAt: 'desc' },
-    });
+    try {
+      return await this.prisma.market.findMany({
+        where: { creatorId },
+        orderBy: { createdAt: 'desc' },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async updateMarketStatus(
@@ -120,13 +110,14 @@ export class MarketRepository extends BaseRepository<Market> {
       resolutionSource?: string;
     }
   ): Promise<Market> {
-    return await this.prisma.market.update({
-      where: { id: marketId },
-      data: {
-        status,
-        ...additionalData,
-      },
-    });
+    try {
+      return await this.prisma.market.update({
+        where: { id: marketId },
+        data: { status, ...additionalData },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async updateMarketVolume(
@@ -134,119 +125,123 @@ export class MarketRepository extends BaseRepository<Market> {
     volumeChange: number,
     incrementParticipants: boolean = false
   ): Promise<Market> {
-    return await this.prisma.market.update({
-      where: { id: marketId },
-      data: {
-        totalVolume: { increment: volumeChange },
-        ...(incrementParticipants && { participantCount: { increment: 1 } }),
-      },
-    });
+    try {
+      return await this.prisma.market.update({
+        where: { id: marketId },
+        data: {
+          totalVolume: { increment: volumeChange },
+          ...(incrementParticipants && { participantCount: { increment: 1 } }),
+        },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
-  async updateLiquidity(
-    marketId: string,
-    yesLiquidity: number,
-    noLiquidity: number
-  ): Promise<Market> {
-    return await this.prisma.market.update({
-      where: { id: marketId },
-      data: { yesLiquidity, noLiquidity },
-    });
+  async updateLiquidity(marketId: string, yesLiquidity: number, noLiquidity: number): Promise<Market> {
+    try {
+      return await this.prisma.market.update({
+        where: { id: marketId },
+        data: { yesLiquidity, noLiquidity },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async setPoolTxHash(marketId: string, txHash: string): Promise<Market> {
-    return await this.prisma.market.update({
-      where: { id: marketId },
-      data: { poolTxHash: txHash },
-    });
+    try {
+      return await this.prisma.market.update({
+        where: { id: marketId },
+        data: { poolTxHash: txHash },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async addFeesCollected(marketId: string, feeAmount: number): Promise<Market> {
-    return await this.prisma.market.update({
-      where: { id: marketId },
-      data: {
-        feesCollected: { increment: feeAmount },
-      },
-    });
+    try {
+      return await this.prisma.market.update({
+        where: { id: marketId },
+        data: { feesCollected: { increment: feeAmount } },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getTrendingMarkets(limit: number = 10): Promise<Market[]> {
-    return await this.prisma.market.findMany({
-      where: {
-        status: MarketStatus.OPEN,
-        closingAt: { gt: new Date() },
-      },
-      orderBy: [{ totalVolume: 'desc' }, { participantCount: 'desc' }],
-      take: limit,
-      include: {
-        creator: {
-          select: {
-            id: true,
-            username: true,
-            displayName: true,
-          },
+    try {
+      return await this.prisma.market.findMany({
+        where: { status: MarketStatus.OPEN, closingAt: { gt: new Date() } },
+        orderBy: [{ totalVolume: 'desc' }, { participantCount: 'desc' }],
+        take: limit,
+        include: {
+          creator: { select: { id: true, username: true, displayName: true } },
         },
-      },
-    });
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
-  async getMarketsByCategory(
-    category: MarketCategory,
-    skip?: number,
-    take?: number
-  ): Promise<Market[]> {
-    return await this.prisma.market.findMany({
-      where: {
-        category,
-        status: MarketStatus.OPEN,
-      },
-      orderBy: { closingAt: 'asc' },
-      skip,
-      take: take || 20,
-    });
+  async getMarketsByCategory(category: MarketCategory, skip?: number, take?: number): Promise<Market[]> {
+    try {
+      return await this.prisma.market.findMany({
+        where: { category, status: MarketStatus.OPEN },
+        orderBy: { closingAt: 'asc' },
+        skip,
+        take: take || 20,
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getClosedMarketsAwaitingResolution(): Promise<Market[]> {
-    return await this.prisma.market.findMany({
-      where: { status: MarketStatus.CLOSED },
-      orderBy: { closedAt: 'asc' },
-    });
+    try {
+      return await this.prisma.market.findMany({
+        where: { status: MarketStatus.CLOSED },
+        orderBy: { closedAt: 'asc' },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getClosingMarkets(withinHours: number = 24): Promise<Market[]> {
-    const closingTime = new Date();
-    closingTime.setHours(closingTime.getHours() + withinHours);
-
-    return await this.prisma.market.findMany({
-      where: {
-        status: MarketStatus.OPEN,
-        closingAt: {
-          gte: new Date(),
-          lte: closingTime,
+    try {
+      const closingTime = new Date();
+      closingTime.setHours(closingTime.getHours() + withinHours);
+      return await this.prisma.market.findMany({
+        where: {
+          status: MarketStatus.OPEN,
+          closingAt: { gte: new Date(), lte: closingTime },
         },
-      },
-      orderBy: { closingAt: 'asc' },
-    });
+        orderBy: { closingAt: 'asc' },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getMarketStatistics() {
-    const [totalMarkets, activeMarkets, totalVolume, avgParticipants] =
-      await Promise.all([
+    try {
+      const [totalMarkets, activeMarkets, totalVolume, avgParticipants] = await Promise.all([
         this.prisma.market.count(),
         this.prisma.market.count({ where: { status: MarketStatus.OPEN } }),
-        this.prisma.market.aggregate({
-          _sum: { totalVolume: true },
-        }),
-        this.prisma.market.aggregate({
-          _avg: { participantCount: true },
-        }),
+        this.prisma.market.aggregate({ _sum: { totalVolume: true } }),
+        this.prisma.market.aggregate({ _avg: { participantCount: true } }),
       ]);
-
-    return {
-      totalMarkets,
-      activeMarkets,
-      totalVolume: totalVolume._sum.totalVolume || 0,
-      avgParticipants: avgParticipants._avg.participantCount || 0,
-    };
+      return {
+        totalMarkets,
+        activeMarkets,
+        totalVolume: totalVolume._sum.totalVolume || 0,
+        avgParticipants: avgParticipants._avg.participantCount || 0,
+      };
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 }

--- a/backend/src/repositories/notification.repository.ts
+++ b/backend/src/repositories/notification.repository.ts
@@ -1,6 +1,6 @@
 // Notification repository - data access layer for notifications
 import { Notification, NotificationType } from '@prisma/client';
-import { BaseRepository } from './base.repository.js';
+import { BaseRepository, toRepositoryError } from './base.repository.js';
 
 export class NotificationRepository extends BaseRepository<Notification> {
   getModelName(): string {
@@ -14,40 +14,53 @@ export class NotificationRepository extends BaseRepository<Notification> {
     message: string;
     metadata?: any;
   }): Promise<Notification> {
-    return await this.prisma.notification.create({
-      data,
-    });
+    try {
+      return await this.prisma.notification.create({ data });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
-  async findByUserId(
-    userId: string,
-    limit: number = 20
-  ): Promise<Notification[]> {
-    return await this.prisma.notification.findMany({
-      where: { userId },
-      orderBy: { createdAt: 'desc' },
-      take: limit,
-    });
+  async findByUserId(userId: string, limit: number = 20): Promise<Notification[]> {
+    try {
+      return await this.prisma.notification.findMany({
+        where: { userId },
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async markAsRead(notificationId: string): Promise<Notification> {
-    return await this.prisma.notification.update({
-      where: { id: notificationId },
-      data: { isRead: true },
-    });
+    try {
+      return await this.prisma.notification.update({
+        where: { id: notificationId },
+        data: { isRead: true },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async markAllAsRead(userId: string): Promise<number> {
-    const result = await this.prisma.notification.updateMany({
-      where: { userId, isRead: false },
-      data: { isRead: true },
-    });
-    return result.count;
+    try {
+      const result = await this.prisma.notification.updateMany({
+        where: { userId, isRead: false },
+        data: { isRead: true },
+      });
+      return result.count;
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getUnreadCount(userId: string): Promise<number> {
-    return await this.prisma.notification.count({
-      where: { userId, isRead: false },
-    });
+    try {
+      return await this.prisma.notification.count({ where: { userId, isRead: false } });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 }

--- a/backend/src/repositories/prediction.repository.ts
+++ b/backend/src/repositories/prediction.repository.ts
@@ -1,6 +1,6 @@
 // Prediction repository - data access layer for predictions
 import { Prediction, PredictionStatus } from '@prisma/client';
-import { BaseRepository } from './base.repository.js';
+import { BaseRepository, toRepositoryError } from './base.repository.js';
 
 export class PredictionRepository extends BaseRepository<Prediction> {
   getModelName(): string {
@@ -17,201 +17,146 @@ export class PredictionRepository extends BaseRepository<Prediction> {
     transactionHash?: string;
     status?: PredictionStatus;
   }): Promise<Prediction> {
-    return await this.prisma.prediction.create({
-      data: {
-        userId: data.userId,
-        marketId: data.marketId,
-        commitmentHash: data.commitmentHash,
-        encryptedSalt: data.encryptedSalt,
-        saltIv: data.saltIv,
-        amountUsdc: data.amountUsdc,
-        transactionHash: data.transactionHash,
-        status: data.status || PredictionStatus.COMMITTED,
-      },
-    });
+    try {
+      return await this.prisma.prediction.create({
+        data: { ...data, status: data.status || PredictionStatus.COMMITTED },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
-  async findByUserAndMarket(
-    userId: string,
-    marketId: string
-  ): Promise<Prediction | null> {
-    return await this.prisma.prediction.findFirst({
-      where: { userId, marketId },
-    });
+  async findByUserAndMarket(userId: string, marketId: string): Promise<Prediction | null> {
+    try {
+      return await this.prisma.prediction.findFirst({ where: { userId, marketId } });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
-  async revealPrediction(
-    predictionId: string,
-    predictedOutcome: number,
-    revealTxHash?: string
-  ): Promise<Prediction> {
-    return await this.prisma.prediction.update({
-      where: { id: predictionId },
-      data: {
-        predictedOutcome,
-        revealTxHash,
-        status: PredictionStatus.REVEALED,
-        revealedAt: new Date(),
-        // Clear encrypted salt after reveal for security
-        encryptedSalt: null,
-        saltIv: null,
-      },
-    });
+  async revealPrediction(predictionId: string, predictedOutcome: number, revealTxHash?: string): Promise<Prediction> {
+    try {
+      return await this.prisma.prediction.update({
+        where: { id: predictionId },
+        data: {
+          predictedOutcome,
+          revealTxHash,
+          status: PredictionStatus.REVEALED,
+          revealedAt: new Date(),
+          encryptedSalt: null,
+          saltIv: null,
+        },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
-  async settlePrediction(
-    predictionId: string,
-    isWinner: boolean,
-    pnlUsd: number
-  ): Promise<Prediction> {
-    return await this.prisma.prediction.update({
-      where: { id: predictionId },
-      data: {
-        status: PredictionStatus.SETTLED,
-        isWinner,
-        pnlUsd,
-        settledAt: new Date(),
-      },
-    });
+  async settlePrediction(predictionId: string, isWinner: boolean, pnlUsd: number): Promise<Prediction> {
+    try {
+      return await this.prisma.prediction.update({
+        where: { id: predictionId },
+        data: { status: PredictionStatus.SETTLED, isWinner, pnlUsd, settledAt: new Date() },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async claimWinnings(predictionId: string): Promise<Prediction> {
-    return await this.prisma.prediction.update({
-      where: { id: predictionId },
-      data: { winningsClaimed: true },
-    });
+    try {
+      return await this.prisma.prediction.update({
+        where: { id: predictionId },
+        data: { winningsClaimed: true },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async findUserPredictions(
     userId: string,
-    options?: {
-      status?: PredictionStatus;
-      skip?: number;
-      take?: number;
-    }
+    options?: { status?: PredictionStatus; skip?: number; take?: number }
   ): Promise<Prediction[]> {
-    return await this.prisma.prediction.findMany({
-      where: {
-        userId,
-        ...(options?.status && { status: options.status }),
-      },
-      orderBy: { createdAt: 'desc' },
-      skip: options?.skip,
-      take: options?.take || 50,
-      include: {
-        market: {
-          select: {
-            id: true,
-            title: true,
-            category: true,
-            status: true,
-            outcomeA: true,
-            outcomeB: true,
-          },
+    try {
+      return await this.prisma.prediction.findMany({
+        where: { userId, ...(options?.status && { status: options.status }) },
+        orderBy: { createdAt: 'desc' },
+        skip: options?.skip,
+        take: options?.take || 50,
+        include: {
+          market: { select: { id: true, title: true, category: true, status: true, outcomeA: true, outcomeB: true } },
         },
-      },
-    });
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async findMarketPredictions(marketId: string): Promise<Prediction[]> {
-    return await this.prisma.prediction.findMany({
-      where: { marketId, status: PredictionStatus.REVEALED },
-      include: {
-        user: {
-          select: {
-            id: true,
-            username: true,
-            displayName: true,
-            avatarUrl: true,
-          },
+    try {
+      return await this.prisma.prediction.findMany({
+        where: { marketId, status: PredictionStatus.REVEALED },
+        include: {
+          user: { select: { id: true, username: true, displayName: true, avatarUrl: true } },
         },
-      },
-    });
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getUnclaimedWinnings(userId: string): Promise<Prediction[]> {
-    return await this.prisma.prediction.findMany({
-      where: {
-        userId,
-        status: PredictionStatus.SETTLED,
-        isWinner: true,
-        winningsClaimed: false,
-      },
-      include: {
-        market: {
-          select: {
-            id: true,
-            title: true,
-            category: true,
-          },
-        },
-      },
-    });
+    try {
+      return await this.prisma.prediction.findMany({
+        where: { userId, status: PredictionStatus.SETTLED, isWinner: true, winningsClaimed: false },
+        include: { market: { select: { id: true, title: true, category: true } } },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getUserPredictionStats(userId: string) {
-    const [total, wins, losses, totalPnl, avgPnl] = await Promise.all([
-      this.prisma.prediction.count({
-        where: { userId, status: PredictionStatus.SETTLED },
-      }),
-      this.prisma.prediction.count({
-        where: { userId, status: PredictionStatus.SETTLED, isWinner: true },
-      }),
-      this.prisma.prediction.count({
-        where: { userId, status: PredictionStatus.SETTLED, isWinner: false },
-      }),
-      this.prisma.prediction.aggregate({
-        where: { userId, status: PredictionStatus.SETTLED },
-        _sum: { pnlUsd: true },
-      }),
-      this.prisma.prediction.aggregate({
-        where: { userId, status: PredictionStatus.SETTLED },
-        _avg: { pnlUsd: true },
-      }),
-    ]);
-
-    return {
-      totalPredictions: total,
-      wins,
-      losses,
-      winRate: total > 0 ? (wins / total) * 100 : 0,
-      totalPnl: totalPnl._sum.pnlUsd || 0,
-      avgPnl: avgPnl._avg.pnlUsd || 0,
-    };
+    try {
+      const [total, wins, losses, totalPnl, avgPnl] = await Promise.all([
+        this.prisma.prediction.count({ where: { userId, status: PredictionStatus.SETTLED } }),
+        this.prisma.prediction.count({ where: { userId, status: PredictionStatus.SETTLED, isWinner: true } }),
+        this.prisma.prediction.count({ where: { userId, status: PredictionStatus.SETTLED, isWinner: false } }),
+        this.prisma.prediction.aggregate({ where: { userId, status: PredictionStatus.SETTLED }, _sum: { pnlUsd: true } }),
+        this.prisma.prediction.aggregate({ where: { userId, status: PredictionStatus.SETTLED }, _avg: { pnlUsd: true } }),
+      ]);
+      return {
+        totalPredictions: total,
+        wins,
+        losses,
+        winRate: total > 0 ? (wins / total) * 100 : 0,
+        totalPnl: totalPnl._sum.pnlUsd || 0,
+        avgPnl: avgPnl._avg.pnlUsd || 0,
+      };
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getMarketPredictionStats(marketId: string) {
-    const [total, yesCount, noCount, totalVolume] = await Promise.all([
-      this.prisma.prediction.count({
-        where: { marketId, status: PredictionStatus.REVEALED },
-      }),
-      this.prisma.prediction.count({
-        where: {
-          marketId,
-          status: PredictionStatus.REVEALED,
-          predictedOutcome: 1,
-        },
-      }),
-      this.prisma.prediction.count({
-        where: {
-          marketId,
-          status: PredictionStatus.REVEALED,
-          predictedOutcome: 0,
-        },
-      }),
-      this.prisma.prediction.aggregate({
-        where: { marketId, status: PredictionStatus.REVEALED },
-        _sum: { amountUsdc: true },
-      }),
-    ]);
-
-    return {
-      totalPredictions: total,
-      yesCount,
-      noCount,
-      yesPercentage: total > 0 ? (yesCount / total) * 100 : 0,
-      noPercentage: total > 0 ? (noCount / total) * 100 : 0,
-      totalVolume: totalVolume._sum.amountUsdc || 0,
-    };
+    try {
+      const [total, yesCount, noCount, totalVolume] = await Promise.all([
+        this.prisma.prediction.count({ where: { marketId, status: PredictionStatus.REVEALED } }),
+        this.prisma.prediction.count({ where: { marketId, status: PredictionStatus.REVEALED, predictedOutcome: 1 } }),
+        this.prisma.prediction.count({ where: { marketId, status: PredictionStatus.REVEALED, predictedOutcome: 0 } }),
+        this.prisma.prediction.aggregate({ where: { marketId, status: PredictionStatus.REVEALED }, _sum: { amountUsdc: true } }),
+      ]);
+      return {
+        totalPredictions: total,
+        yesCount,
+        noCount,
+        yesPercentage: total > 0 ? (yesCount / total) * 100 : 0,
+        noPercentage: total > 0 ? (noCount / total) * 100 : 0,
+        totalVolume: totalVolume._sum.amountUsdc || 0,
+      };
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 }

--- a/backend/src/repositories/share.repository.ts
+++ b/backend/src/repositories/share.repository.ts
@@ -1,49 +1,33 @@
-// backend/src/repositories/share.repository.ts
-// Repository for managing user share positions
-
-import { prisma } from '../database/prisma.js';
-import { Prisma, Share } from '@prisma/client';
+// Share repository - data access layer for user share positions
+import { Share, Prisma } from '@prisma/client';
 import { Decimal } from '@prisma/client/runtime/library';
+import { BaseRepository } from './base.repository.js';
 
-export class ShareRepository {
-  /**
-   * Find a user's share position for a specific market and outcome
-   */
+export class ShareRepository extends BaseRepository<Share> {
+  getModelName(): string {
+    return 'share';
+  }
+
   async findByUserMarketOutcome(
     userId: string,
     marketId: string,
     outcome: number
   ): Promise<Share | null> {
-    return prisma.share.findFirst({
-      where: {
-        userId,
-        marketId,
-        outcome,
-      },
+    return this.prisma.share.findFirst({
+      where: { userId, marketId, outcome },
     });
   }
 
-  /**
-   * Find all shares for a user in a specific market
-   */
   async findByUserAndMarket(
     userId: string,
     marketId: string
   ): Promise<Share[]> {
-    return prisma.share.findMany({
-      where: {
-        userId,
-        marketId,
-      },
-      include: {
-        market: true,
-      },
+    return this.prisma.share.findMany({
+      where: { userId, marketId },
+      include: { market: true },
     });
   }
 
-  /**
-   * Create a new share position
-   */
   async createPosition(data: {
     userId: string;
     marketId: string;
@@ -54,23 +38,18 @@ export class ShareRepository {
     currentValue: number;
     unrealizedPnl: number;
   }): Promise<Share> {
-    return prisma.share.create({
-      data: {
-        userId: data.userId,
-        marketId: data.marketId,
-        outcome: data.outcome,
-        quantity: new Decimal(data.quantity),
-        costBasis: new Decimal(data.costBasis),
-        entryPrice: new Decimal(data.entryPrice),
-        currentValue: new Decimal(data.currentValue),
-        unrealizedPnl: new Decimal(data.unrealizedPnl),
-      },
+    return this.create({
+      userId: data.userId,
+      marketId: data.marketId,
+      outcome: data.outcome,
+      quantity: new Decimal(data.quantity),
+      costBasis: new Decimal(data.costBasis),
+      entryPrice: new Decimal(data.entryPrice),
+      currentValue: new Decimal(data.currentValue),
+      unrealizedPnl: new Decimal(data.unrealizedPnl),
     });
   }
 
-  /**
-   * Update an existing share position
-   */
   async updatePosition(
     shareId: string,
     data: Partial<{
@@ -99,108 +78,73 @@ export class ShareRepository {
     if (data.realizedPnl !== undefined)
       updateData.realizedPnl = new Decimal(data.realizedPnl);
 
-    return prisma.share.update({
-      where: { id: shareId },
-      data: updateData,
-    });
+    return this.update(shareId, updateData);
   }
 
-  /**
-   * Increment shares for an existing position (used when buying more)
-   */
   async incrementShares(
     shareId: string,
     additionalQuantity: number,
     additionalCost: number,
     newEntryPrice: number
   ): Promise<Share> {
-    const share = await prisma.share.findUnique({ where: { id: shareId } });
-    if (!share) {
-      throw new Error('Share position not found');
-    }
+    const share = await this.findById(shareId);
+    if (!share) throw new Error('Share position not found');
 
     const newQuantity = Number(share.quantity) + additionalQuantity;
     const newCostBasis = Number(share.costBasis) + additionalCost;
     const newCurrentValue = newQuantity * newEntryPrice;
-    const newUnrealizedPnl = newCurrentValue - newCostBasis;
 
     return this.updatePosition(shareId, {
       quantity: newQuantity,
       costBasis: newCostBasis,
       currentValue: newCurrentValue,
-      unrealizedPnl: newUnrealizedPnl,
+      unrealizedPnl: newCurrentValue - newCostBasis,
     });
   }
 
-  /**
-   * Decrement shares for an existing position (used when selling)
-   */
   async decrementShares(
     shareId: string,
     quantityToSell: number,
     proceeds: number
   ): Promise<Share> {
-    const share = await prisma.share.findUnique({ where: { id: shareId } });
-    if (!share) {
-      throw new Error('Share position not found');
-    }
+    const share = await this.findById(shareId);
+    if (!share) throw new Error('Share position not found');
 
     const currentQuantity = Number(share.quantity);
-    if (currentQuantity < quantityToSell) {
+    if (currentQuantity < quantityToSell)
       throw new Error('Insufficient shares to sell');
-    }
 
     const newQuantity = currentQuantity - quantityToSell;
     const proportionSold = quantityToSell / currentQuantity;
     const costOfSoldShares = Number(share.costBasis) * proportionSold;
     const newCostBasis = Number(share.costBasis) - costOfSoldShares;
     const newSoldQuantity = Number(share.soldQuantity) + quantityToSell;
-    const tradeRealizedPnl = proceeds - costOfSoldShares;
-    const totalRealizedPnl = Number(share.realizedPnl || 0) + tradeRealizedPnl;
-
-    // Update current value and unrealized PnL based on remaining shares
-    const currentPrice = Number(share.entryPrice); // Use current market price if available
+    const totalRealizedPnl =
+      Number(share.realizedPnl || 0) + (proceeds - costOfSoldShares);
+    const currentPrice = Number(share.entryPrice);
     const newCurrentValue = newQuantity * currentPrice;
-    const newUnrealizedPnl = newCurrentValue - newCostBasis;
 
     return this.updatePosition(shareId, {
       quantity: newQuantity,
       costBasis: newCostBasis,
       currentValue: newCurrentValue,
-      unrealizedPnl: newUnrealizedPnl,
+      unrealizedPnl: newCurrentValue - newCostBasis,
       soldQuantity: newSoldQuantity,
       soldAt: new Date(),
       realizedPnl: totalRealizedPnl,
     });
   }
 
-  /**
-   * Get all active positions for a user (quantity > 0)
-   */
   async findActivePositionsByUser(userId: string): Promise<Share[]> {
-    return prisma.share.findMany({
-      where: {
-        userId,
-        quantity: {
-          gt: 0,
-        },
-      },
-      include: {
-        market: true,
-      },
-      orderBy: {
-        acquiredAt: 'desc',
-      },
+    return this.prisma.share.findMany({
+      where: { userId, quantity: { gt: 0 } },
+      include: { market: true },
+      orderBy: { acquiredAt: 'desc' },
     });
   }
 
-  /**
-   * Delete a share position (if quantity becomes 0)
-   */
   async deletePosition(shareId: string): Promise<void> {
-    await prisma.share.delete({
-      where: { id: shareId },
-    });
+    await this.delete(shareId);
   }
 }
 

--- a/backend/src/repositories/trade.repository.ts
+++ b/backend/src/repositories/trade.repository.ts
@@ -1,6 +1,6 @@
 // Trade repository - data access layer for trades
 import { Trade, TradeType, TradeStatus } from '@prisma/client';
-import { BaseRepository } from './base.repository.js';
+import { BaseRepository, toRepositoryError } from './base.repository.js';
 
 export class TradeRepository extends BaseRepository<Trade> {
   getModelName(): string {
@@ -18,185 +18,151 @@ export class TradeRepository extends BaseRepository<Trade> {
     feeAmount: number;
     txHash: string;
   }): Promise<Trade> {
-    return await this.prisma.trade.create({
-      data: {
-        ...data,
-        status: TradeStatus.PENDING,
-      },
-    });
+    try {
+      return await this.prisma.trade.create({ data: { ...data, status: TradeStatus.PENDING } });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async confirmTrade(tradeId: string): Promise<Trade> {
-    return await this.prisma.trade.update({
-      where: { id: tradeId },
-      data: {
-        status: TradeStatus.CONFIRMED,
-        confirmedAt: new Date(),
-      },
-    });
+    try {
+      return await this.prisma.trade.update({
+        where: { id: tradeId },
+        data: { status: TradeStatus.CONFIRMED, confirmedAt: new Date() },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async failTrade(tradeId: string): Promise<Trade> {
-    return await this.prisma.trade.update({
-      where: { id: tradeId },
-      data: {
-        status: TradeStatus.FAILED,
-      },
-    });
+    try {
+      return await this.prisma.trade.update({
+        where: { id: tradeId },
+        data: { status: TradeStatus.FAILED },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async findByTxHash(txHash: string): Promise<Trade | null> {
-    return await this.prisma.trade.findFirst({
-      where: { txHash },
-    });
+    try {
+      return await this.prisma.trade.findFirst({ where: { txHash } });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async findUserTrades(
     userId: string,
-    options?: {
-      tradeType?: TradeType;
-      status?: TradeStatus;
-      skip?: number;
-      take?: number;
-    }
+    options?: { tradeType?: TradeType; status?: TradeStatus; skip?: number; take?: number }
   ): Promise<Trade[]> {
-    return await this.prisma.trade.findMany({
-      where: {
-        userId,
-        ...(options?.tradeType && { tradeType: options.tradeType }),
-        ...(options?.status && { status: options.status }),
-      },
-      orderBy: { createdAt: 'desc' },
-      skip: options?.skip,
-      take: options?.take || 50,
-      include: {
-        market: {
-          select: {
-            id: true,
-            title: true,
-            category: true,
-          },
+    try {
+      return await this.prisma.trade.findMany({
+        where: {
+          userId,
+          ...(options?.tradeType && { tradeType: options.tradeType }),
+          ...(options?.status && { status: options.status }),
         },
-      },
-    });
+        orderBy: { createdAt: 'desc' },
+        skip: options?.skip,
+        take: options?.take || 50,
+        include: { market: { select: { id: true, title: true, category: true } } },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
-  async findMarketTrades(
-    marketId: string,
-    options?: {
-      skip?: number;
-      take?: number;
+  async findMarketTrades(marketId: string, options?: { skip?: number; take?: number }): Promise<Trade[]> {
+    try {
+      return await this.prisma.trade.findMany({
+        where: { marketId, status: TradeStatus.CONFIRMED },
+        orderBy: { createdAt: 'desc' },
+        skip: options?.skip,
+        take: options?.take || 100,
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
     }
-  ): Promise<Trade[]> {
-    return await this.prisma.trade.findMany({
-      where: { marketId, status: TradeStatus.CONFIRMED },
-      orderBy: { createdAt: 'desc' },
-      skip: options?.skip,
-      take: options?.take || 100,
-    });
   }
 
   async getUserTradeVolume(userId: string): Promise<number> {
-    const result = await this.prisma.trade.aggregate({
-      where: {
-        userId,
-        status: TradeStatus.CONFIRMED,
-        tradeType: { in: [TradeType.BUY, TradeType.SELL] },
-      },
-      _sum: { totalAmount: true },
-    });
-
-    return Number(result._sum.totalAmount || 0);
+    try {
+      const result = await this.prisma.trade.aggregate({
+        where: { userId, status: TradeStatus.CONFIRMED, tradeType: { in: [TradeType.BUY, TradeType.SELL] } },
+        _sum: { totalAmount: true },
+      });
+      return Number(result._sum.totalAmount || 0);
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getMarketTradeVolume(marketId: string): Promise<number> {
-    const result = await this.prisma.trade.aggregate({
-      where: {
-        marketId,
-        status: TradeStatus.CONFIRMED,
-        tradeType: { in: [TradeType.BUY, TradeType.SELL] },
-      },
-      _sum: { totalAmount: true },
-    });
-
-    return Number(result._sum.totalAmount || 0);
+    try {
+      const result = await this.prisma.trade.aggregate({
+        where: { marketId, status: TradeStatus.CONFIRMED, tradeType: { in: [TradeType.BUY, TradeType.SELL] } },
+        _sum: { totalAmount: true },
+      });
+      return Number(result._sum.totalAmount || 0);
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getTotalFeesCollected(): Promise<number> {
-    const result = await this.prisma.trade.aggregate({
-      where: { status: TradeStatus.CONFIRMED },
-      _sum: { feeAmount: true },
-    });
-
-    return Number(result._sum.feeAmount || 0);
+    try {
+      const result = await this.prisma.trade.aggregate({
+        where: { status: TradeStatus.CONFIRMED },
+        _sum: { feeAmount: true },
+      });
+      return Number(result._sum.feeAmount || 0);
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getRecentTrades(limit: number = 20): Promise<Trade[]> {
-    return await this.prisma.trade.findMany({
-      where: { status: TradeStatus.CONFIRMED },
-      orderBy: { confirmedAt: 'desc' },
-      take: limit,
-      include: {
-        user: {
-          select: {
-            id: true,
-            username: true,
-            displayName: true,
-          },
+    try {
+      return await this.prisma.trade.findMany({
+        where: { status: TradeStatus.CONFIRMED },
+        orderBy: { confirmedAt: 'desc' },
+        take: limit,
+        include: {
+          user: { select: { id: true, username: true, displayName: true } },
+          market: { select: { id: true, title: true, category: true } },
         },
-        market: {
-          select: {
-            id: true,
-            title: true,
-            category: true,
-          },
-        },
-      },
-    });
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async createBuyTrade(data: {
-    userId: string;
-    marketId: string;
-    outcome: number;
-    quantity: number;
-    pricePerUnit: number;
-    totalAmount: number;
-    feeAmount: number;
-    txHash: string;
+    userId: string; marketId: string; outcome: number;
+    quantity: number; pricePerUnit: number; totalAmount: number; feeAmount: number; txHash: string;
   }): Promise<Trade> {
-    return this.createTrade({
-      ...data,
-      tradeType: TradeType.BUY,
-    });
+    return this.createTrade({ ...data, tradeType: TradeType.BUY });
   }
 
   async createSellTrade(data: {
-    userId: string;
-    marketId: string;
-    outcome: number;
-    quantity: number;
-    pricePerUnit: number;
-    totalAmount: number;
-    feeAmount: number;
-    txHash: string;
+    userId: string; marketId: string; outcome: number;
+    quantity: number; pricePerUnit: number; totalAmount: number; feeAmount: number; txHash: string;
   }): Promise<Trade> {
-    return this.createTrade({
-      ...data,
-      tradeType: TradeType.SELL,
-    });
+    return this.createTrade({ ...data, tradeType: TradeType.SELL });
   }
 
-  async findByUserAndMarket(
-    userId: string,
-    marketId: string
-  ): Promise<Trade[]> {
-    return await this.prisma.trade.findMany({
-      where: {
-        userId,
-        marketId,
-      },
-      orderBy: { createdAt: 'desc' },
-    });
+  async findByUserAndMarket(userId: string, marketId: string): Promise<Trade[]> {
+    try {
+      return await this.prisma.trade.findMany({
+        where: { userId, marketId },
+        orderBy: { createdAt: 'desc' },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 }

--- a/backend/src/repositories/user.repository.ts
+++ b/backend/src/repositories/user.repository.ts
@@ -1,6 +1,6 @@
 // User repository - data access layer for users
 import { User, UserTier, Prisma } from '@prisma/client';
-import { BaseRepository } from './base.repository.js';
+import { BaseRepository, toRepositoryError } from './base.repository.js';
 
 export class UserRepository extends BaseRepository<User> {
   getModelName(): string {
@@ -8,21 +8,27 @@ export class UserRepository extends BaseRepository<User> {
   }
 
   async findByEmail(email: string): Promise<User | null> {
-    return await this.prisma.user.findUnique({
-      where: { email },
-    });
+    try {
+      return await this.prisma.user.findUnique({ where: { email } });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async findByUsername(username: string): Promise<User | null> {
-    return await this.prisma.user.findUnique({
-      where: { username },
-    });
+    try {
+      return await this.prisma.user.findUnique({ where: { username } });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async findByWalletAddress(walletAddress: string): Promise<User | null> {
-    return await this.prisma.user.findUnique({
-      where: { walletAddress },
-    });
+    try {
+      return await this.prisma.user.findUnique({ where: { walletAddress } });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async createUser(data: {
@@ -32,97 +38,95 @@ export class UserRepository extends BaseRepository<User> {
     displayName?: string;
     walletAddress?: string;
   }): Promise<User> {
-    return await this.prisma.user.create({
-      data,
-    });
+    try {
+      return await this.prisma.user.create({ data });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
-  async updateBalance(
-    userId: string,
-    usdcBalance?: number,
-    xlmBalance?: number
-  ): Promise<User> {
-    const updateData: any = {};
-    if (usdcBalance !== undefined) updateData.usdcBalance = usdcBalance;
-    if (xlmBalance !== undefined) updateData.xlmBalance = xlmBalance;
-
-    return await this.prisma.user.update({
-      where: { id: userId },
-      data: updateData,
-    });
+  async updateBalance(userId: string, usdcBalance?: number, xlmBalance?: number): Promise<User> {
+    try {
+      const updateData: any = {};
+      if (usdcBalance !== undefined) updateData.usdcBalance = usdcBalance;
+      if (xlmBalance !== undefined) updateData.xlmBalance = xlmBalance;
+      return await this.prisma.user.update({ where: { id: userId }, data: updateData });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
-  async updateWalletAddress(
-    userId: string,
-    walletAddress: string
-  ): Promise<User> {
-    return await this.prisma.user.update({
-      where: { id: userId },
-      data: { walletAddress },
-    });
+  async updateWalletAddress(userId: string, walletAddress: string): Promise<User> {
+    try {
+      return await this.prisma.user.update({ where: { id: userId }, data: { walletAddress } });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async updateTier(userId: string, tier: UserTier): Promise<User> {
-    return await this.prisma.user.update({
-      where: { id: userId },
-      data: { tier },
-    });
+    try {
+      return await this.prisma.user.update({ where: { id: userId }, data: { tier } });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async updateLastLogin(userId: string): Promise<User> {
-    return await this.prisma.user.update({
-      where: { id: userId },
-      data: { lastLogin: new Date() },
-    });
+    try {
+      return await this.prisma.user.update({ where: { id: userId }, data: { lastLogin: new Date() } });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
-  async searchUsers(
-    query: string,
-    limit: number = 10
-  ): Promise<Partial<User>[]> {
-    return await this.prisma.user.findMany({
-      where: {
-        OR: [
-          { username: { contains: query, mode: 'insensitive' } },
-          { displayName: { contains: query, mode: 'insensitive' } },
-        ],
-        isActive: true,
-      },
-      take: limit,
-      select: {
-        id: true,
-        username: true,
-        displayName: true,
-        avatarUrl: true,
-        tier: true,
-        reputationScore: true,
-        createdAt: true,
-      },
-    });
+  async searchUsers(query: string, limit: number = 10): Promise<Partial<User>[]> {
+    try {
+      return await this.prisma.user.findMany({
+        where: {
+          OR: [
+            { username: { contains: query, mode: 'insensitive' } },
+            { displayName: { contains: query, mode: 'insensitive' } },
+          ],
+          isActive: true,
+        },
+        take: limit,
+        select: {
+          id: true,
+          username: true,
+          displayName: true,
+          avatarUrl: true,
+          tier: true,
+          reputationScore: true,
+          createdAt: true,
+        },
+      });
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 
   async getUserStats(userId: string) {
-    const [user, predictionCount, winCount, totalPnl] = await Promise.all([
-      this.findById(userId),
-      this.prisma.prediction.count({
-        where: { userId, status: 'SETTLED' },
-      }),
-      this.prisma.prediction.count({
-        where: { userId, status: 'SETTLED', isWinner: true },
-      }),
-      this.prisma.prediction.aggregate({
-        where: { userId, status: 'SETTLED' },
-        _sum: { pnlUsd: true },
-      }),
-    ]);
-
-    return {
-      user,
-      predictionCount,
-      winCount,
-      lossCount: predictionCount - winCount,
-      winRate: predictionCount > 0 ? (winCount / predictionCount) * 100 : 0,
-      totalPnl: totalPnl._sum.pnlUsd || 0,
-    };
+    try {
+      const [user, predictionCount, winCount, totalPnl] = await Promise.all([
+        this.findById(userId),
+        this.prisma.prediction.count({ where: { userId, status: 'SETTLED' } }),
+        this.prisma.prediction.count({ where: { userId, status: 'SETTLED', isWinner: true } }),
+        this.prisma.prediction.aggregate({
+          where: { userId, status: 'SETTLED' },
+          _sum: { pnlUsd: true },
+        }),
+      ]);
+      return {
+        user,
+        predictionCount,
+        winCount,
+        lossCount: predictionCount - winCount,
+        winRate: predictionCount > 0 ? (winCount / predictionCount) * 100 : 0,
+        totalPnl: totalPnl._sum.pnlUsd || 0,
+      };
+    } catch (err) {
+      throw toRepositoryError(this.getModelName(), err);
+    }
   }
 }

--- a/backend/tests/repositories/base.repository.test.ts
+++ b/backend/tests/repositories/base.repository.test.ts
@@ -1,0 +1,226 @@
+// Unit tests for BaseRepository
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  BaseRepository,
+  RepositoryError,
+} from '../../src/repositories/base.repository.js';
+
+// Helper: create a fake PrismaClientKnownRequestError (duck-typed)
+function makePrismaKnownError(code: string): Error & { code: string } {
+  const err = new Error(`Prisma error ${code}`) as Error & { code: string };
+  err.name = 'PrismaClientKnownRequestError';
+  err.code = code;
+  Object.defineProperty(err, 'constructor', {
+    value: { name: 'PrismaClientKnownRequestError' },
+  });
+  return err;
+}
+
+// ─── Minimal concrete subclass for testing ────────────────────────────────────
+
+class TestRepository extends BaseRepository<{ id: string; name: string }> {
+  getModelName(): string {
+    return 'testModel';
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeMockModel(overrides: Record<string, unknown> = {}) {
+  return {
+    findUnique: vi.fn().mockResolvedValue(null),
+    findMany: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    count: vi.fn().mockResolvedValue(0),
+    ...overrides,
+  };
+}
+
+function makePrismaClient(model: ReturnType<typeof makeMockModel>) {
+  return { testModel: model } as any;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('BaseRepository', () => {
+  let mockModel: ReturnType<typeof makeMockModel>;
+  let repo: TestRepository;
+
+  beforeEach(() => {
+    mockModel = makeMockModel();
+    repo = new TestRepository(makePrismaClient(mockModel));
+  });
+
+  // ── findById ──────────────────────────────────────────────────────────────
+
+  describe('findById', () => {
+    it('returns null when record does not exist', async () => {
+      mockModel.findUnique.mockResolvedValue(null);
+
+      const result = await repo.findById('non-existent-id');
+
+      expect(result).toBeNull();
+      expect(mockModel.findUnique).toHaveBeenCalledWith({
+        where: { id: 'non-existent-id' },
+      });
+    });
+
+    it('returns the record when it exists', async () => {
+      const record = { id: '123', name: 'test' };
+      mockModel.findUnique.mockResolvedValue(record);
+
+      const result = await repo.findById('123');
+
+      expect(result).toEqual(record);
+    });
+
+    it('forwards select and include options', async () => {
+      const select = { id: true };
+      const include = { relations: true };
+      await repo.findById('123', { select, include });
+
+      expect(mockModel.findUnique).toHaveBeenCalledWith({
+        where: { id: '123' },
+        select,
+        include,
+      });
+    });
+
+    it('throws RepositoryError on Prisma known error', async () => {
+      const prismaError = makePrismaKnownError('P2002');
+      mockModel.findUnique.mockRejectedValue(prismaError);
+
+      await expect(repo.findById('123')).rejects.toBeInstanceOf(
+        RepositoryError
+      );
+    });
+  });
+
+  // ── findMany ──────────────────────────────────────────────────────────────
+
+  describe('findMany', () => {
+    it('returns empty array when no records exist', async () => {
+      const result = await repo.findMany();
+      expect(result).toEqual([]);
+    });
+
+    it('passes where, select, orderBy, skip, take, include to Prisma', async () => {
+      const options = {
+        where: { name: 'x' },
+        select: { id: true },
+        orderBy: { id: 'asc' },
+        skip: 5,
+        take: 10,
+        include: { rel: true },
+      };
+      await repo.findMany(options);
+      expect(mockModel.findMany).toHaveBeenCalledWith(options);
+    });
+
+    it('throws RepositoryError on Prisma error', async () => {
+      mockModel.findMany.mockRejectedValue(makePrismaKnownError('P2025'));
+      await expect(repo.findMany()).rejects.toBeInstanceOf(RepositoryError);
+    });
+  });
+
+  // ── create ────────────────────────────────────────────────────────────────
+
+  describe('create', () => {
+    it('creates a record and returns it', async () => {
+      const record = { id: '1', name: 'new' };
+      mockModel.create.mockResolvedValue(record);
+
+      const result = await repo.create({ name: 'new' });
+
+      expect(result).toEqual(record);
+      expect(mockModel.create).toHaveBeenCalledWith({ data: { name: 'new' } });
+    });
+
+    it('throws RepositoryError on unique constraint violation', async () => {
+      mockModel.create.mockRejectedValue(makePrismaKnownError('P2002'));
+      await expect(repo.create({ name: 'dup' })).rejects.toMatchObject({
+        code: 'UNIQUE_CONSTRAINT',
+      });
+    });
+  });
+
+  // ── update ────────────────────────────────────────────────────────────────
+
+  describe('update', () => {
+    it('updates a record and returns it', async () => {
+      const updated = { id: '1', name: 'updated' };
+      mockModel.update.mockResolvedValue(updated);
+
+      const result = await repo.update('1', { name: 'updated' });
+
+      expect(result).toEqual(updated);
+      expect(mockModel.update).toHaveBeenCalledWith({
+        where: { id: '1' },
+        data: { name: 'updated' },
+      });
+    });
+
+    it('throws RepositoryError with NOT_FOUND when record is missing', async () => {
+      mockModel.update.mockRejectedValue(makePrismaKnownError('P2025'));
+      await expect(repo.update('missing', {})).rejects.toMatchObject({
+        code: 'NOT_FOUND',
+      });
+    });
+  });
+
+  // ── delete ────────────────────────────────────────────────────────────────
+
+  describe('delete', () => {
+    it('deletes a record and returns it', async () => {
+      const deleted = { id: '1', name: 'gone' };
+      mockModel.delete.mockResolvedValue(deleted);
+
+      const result = await repo.delete('1');
+
+      expect(result).toEqual(deleted);
+      expect(mockModel.delete).toHaveBeenCalledWith({ where: { id: '1' } });
+    });
+
+    it('throws RepositoryError on Prisma error', async () => {
+      mockModel.delete.mockRejectedValue(makePrismaKnownError('P2025'));
+      await expect(repo.delete('missing')).rejects.toBeInstanceOf(
+        RepositoryError
+      );
+    });
+  });
+
+  // ── count ─────────────────────────────────────────────────────────────────
+
+  describe('count', () => {
+    it('returns 0 when no records match', async () => {
+      const result = await repo.count({ name: 'nobody' });
+      expect(result).toBe(0);
+    });
+
+    it('passes where clause to Prisma', async () => {
+      mockModel.count.mockResolvedValue(3);
+      const result = await repo.count({ name: 'x' });
+      expect(result).toBe(3);
+      expect(mockModel.count).toHaveBeenCalledWith({ where: { name: 'x' } });
+    });
+  });
+
+  // ── RepositoryError ───────────────────────────────────────────────────────
+
+  describe('RepositoryError', () => {
+    it('has the correct name and code', () => {
+      const err = new RepositoryError('NOT_FOUND', 'not found');
+      expect(err.name).toBe('RepositoryError');
+      expect(err.code).toBe('NOT_FOUND');
+      expect(err.message).toBe('not found');
+    });
+
+    it('preserves the original cause', () => {
+      const cause = new Error('original');
+      const err = new RepositoryError('UNKNOWN', 'wrapped', cause);
+      expect(err.cause).toBe(cause);
+    });
+  });
+});


### PR DESCRIPTION
Closes #389 

Wraps all base CRUD methods (findById, findMany, create, update, delete, count) in try/catch
Throws RepositoryError with typed codes (NOT_FOUND, UNIQUE_CONSTRAINT, FOREIGN_KEY_CONSTRAINT, QUERY_ERROR, UNKNOWN) instead of leaking raw Prisma errors
Accepts select and include options on findById and findMany
Exports toRepositoryError so subclasses can wrap their own domain-specific Prisma calls