### PR TITLE
feat(notifications): implement notification preference management (#32)

### DIFF
--- a/backend/prisma/migrations/20260328000000_add_trade_filled_preference/migration.sql
+++ b/backend/prisma/migrations/20260328000000_add_trade_filled_preference/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN "notify_trade_filled" BOOLEAN NOT NULL DEFAULT true;
+
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE 'TRADE_FILLED';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -41,6 +41,7 @@ model User {
   notifyMarketResolution Boolean @default(true) @map("notify_market_resolution")
   notifyWinnings         Boolean @default(true) @map("notify_winnings")
   notifyAchievements     Boolean @default(true) @map("notify_achievements")
+  notifyTradeFilled      Boolean @default(true) @map("notify_trade_filled")
   emailNotifications     Boolean @default(false) @map("email_notifications")
 
   // Relations
@@ -101,6 +102,7 @@ enum NotificationType {
   MARKET_RESOLVED
   PREDICTION_RESULT
   WINNINGS_AVAILABLE
+  TRADE_FILLED
 }
 
 // ============================================================================

--- a/backend/src/controllers/notifications.controller.ts
+++ b/backend/src/controllers/notifications.controller.ts
@@ -133,6 +133,7 @@ export async function updateNotificationPreferences(
       notifyMarketResolution,
       notifyWinnings,
       notifyAchievements,
+      notifyTradeFilled,
       emailNotifications,
     } = req.body;
 
@@ -143,6 +144,7 @@ export async function updateNotificationPreferences(
         notifyMarketResolution,
         notifyWinnings,
         notifyAchievements,
+        notifyTradeFilled,
         emailNotifications,
       }
     );
@@ -154,6 +156,7 @@ export async function updateNotificationPreferences(
         notifyMarketResolution: user.notifyMarketResolution,
         notifyWinnings: user.notifyWinnings,
         notifyAchievements: user.notifyAchievements,
+        notifyTradeFilled: user.notifyTradeFilled,
         emailNotifications: user.emailNotifications,
       },
     });
@@ -196,6 +199,7 @@ export async function getNotificationPreferences(
         notifyMarketResolution: user.notifyMarketResolution,
         notifyWinnings: user.notifyWinnings,
         notifyAchievements: user.notifyAchievements,
+        notifyTradeFilled: user.notifyTradeFilled,
         emailNotifications: user.emailNotifications,
       },
     });

--- a/backend/src/routes/notifications.routes.ts
+++ b/backend/src/routes/notifications.routes.ts
@@ -128,7 +128,7 @@ router.get('/preferences', requireAuth, getNotificationPreferences);
 /**
  * @swagger
  * /api/notifications/preferences:
- *   put:
+ *   patch:
  *     summary: Update notification preferences
  *     tags: [Notifications]
  *     security:
@@ -147,6 +147,8 @@ router.get('/preferences', requireAuth, getNotificationPreferences);
  *               notifyWinnings:
  *                 type: boolean
  *               notifyAchievements:
+ *                 type: boolean
+ *               notifyTradeFilled:
  *                 type: boolean
  *               emailNotifications:
  *                 type: boolean
@@ -171,11 +173,14 @@ router.get('/preferences', requireAuth, getNotificationPreferences);
  *                       type: boolean
  *                     notifyAchievements:
  *                       type: boolean
+ *                     notifyTradeFilled:
+ *                       type: boolean
  *                     emailNotifications:
  *                       type: boolean
  *       401:
  *         description: Unauthorized
  */
+router.patch('/preferences', requireAuth, updateNotificationPreferences);
 router.put('/preferences', requireAuth, updateNotificationPreferences);
 
 /**

--- a/backend/src/services/notification.service.ts
+++ b/backend/src/services/notification.service.ts
@@ -104,6 +104,8 @@ export class NotificationService {
       case NotificationType.ACHIEVEMENT:
       case NotificationType.TIER_UPGRADE:
         return user.notifyAchievements ?? true;
+      case NotificationType.TRADE_FILLED:
+        return user.notifyTradeFilled ?? true;
       case NotificationType.SYSTEM:
         return true; // Always send system notifications
       default:
@@ -312,6 +314,7 @@ export class NotificationService {
       notifyMarketResolution?: boolean;
       notifyWinnings?: boolean;
       notifyAchievements?: boolean;
+      notifyTradeFilled?: boolean;
       emailNotifications?: boolean;
     }
   ) {


### PR DESCRIPTION

Closes #376 

## What

Adds full user notification preference management — users can opt in/out of specific 
notification types, with preferences persisted in the DB and respected before sending.

## Changes

- PATCH /notifications/preferences — update preferences (e.g. disable trade_filled emails);
PUT kept for backward compat
- GET /notifications/preferences — returns current preferences
- Migration add_trade_filled_preference — adds notify_trade_filled column and TRADE_FILLED 
enum value
- notification.service.ts — shouldNotifyUser now checks notifyTradeFilled before sending; 
preferences type updated
- Controller updated to wire notifyTradeFilled through get/update handlers

## Acceptance Criteria

- [x] GET /notifications/preferences returns current preferences
- [x] PATCH /notifications/preferences updates preferences
- [x] Preferences persisted in DB via migration
- [x] notification.service.ts respects preferences before sending
