### PR TITLE
feat:  successfully implemented the market resolution via oracle

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -164,6 +164,7 @@ enum MarketCategory {
 enum MarketStatus {
   OPEN
   CLOSED
+  REPORTED
   RESOLVED
   DISPUTED
   CANCELLED

--- a/backend/src/controllers/oracle.controller.ts
+++ b/backend/src/controllers/oracle.controller.ts
@@ -93,48 +93,50 @@ export class OracleController {
 
   /**
    * POST /api/markets/:id/resolve
-   * Admin Only
+   * Admin/Oracle Only
+   * Phase 1 of resolution: Report the winning outcome
    */
   async resolveMarket(req: AuthenticatedRequest, res: Response): Promise<void> {
     try {
       const marketId = String(req.params.id);
+      const { outcome } = req.body;
+
       const market = await this.marketService.getMarketDetails(marketId);
 
-      // 1. Check if consensus reached on-chain
-      const winningOutcome = await oracleService.checkConsensus(
-        market.contractAddress
-      );
-      if (winningOutcome === null) {
-        res
-          .status(400)
-          .json({ success: false, error: 'Consensus not yet reached' });
+      // 1. Validate: Market must be CLOSED to report outcome
+      if (market.status !== 'CLOSED') {
+        res.status(409).json({
+          success: false,
+          error: `Market is in ${market.status} state, but must be CLOSED to resolve.`,
+        });
         return;
       }
 
-      // 2. Resolve on-chain
-      const blockchainResult = await marketBlockchainService.resolveMarket(
-        market.contractAddress
+      // 2. Call blockchain: Report outcome (Phase 1)
+      const blockchainTxHash = await oracleService.reportOutcome(
+        market.contractAddress,
+        outcome
       );
 
-      // 3. Update DB
-      const resolvedMarket = await this.marketService.resolveMarket(
+      // 3. Update DB: Set status to REPORTED
+      const reportedMarket = await this.marketService.reportMarketOutcome(
         marketId,
-        winningOutcome,
-        'Oracle Consensus'
+        outcome,
+        'Oracle Reporting'
       );
 
-      res.json({
+      res.status(200).json({
         success: true,
         data: {
-          txHash: blockchainResult.txHash,
-          market: resolvedMarket,
+          txHash: blockchainTxHash,
+          market: reportedMarket,
         },
       });
     } catch (error) {
-      (req.log || logger).error('Resolve error', { error });
+      (req.log || logger).error('Resolve (Report) error', { error });
       res.status(500).json({
         success: false,
-        error: error instanceof Error ? error.message : 'Resolution failed',
+        error: error instanceof Error ? error.message : 'Reporting failed',
       });
     }
   }

--- a/backend/src/routes/oracle.ts
+++ b/backend/src/routes/oracle.ts
@@ -122,7 +122,7 @@ router.post(
 router.post(
   '/:id/resolve',
   requireAuth,
-  validate({ params: uuidParam }),
+  validate({ params: uuidParam, body: resolveMarketBody }),
   (req, res) => oracleController.resolveMarket(req, res)
 );
 

--- a/backend/src/schemas/validation.schemas.ts
+++ b/backend/src/schemas/validation.schemas.ts
@@ -219,6 +219,10 @@ export const attestBody = z.object({
   outcome: z.number().int().min(0).max(1),
 });
 
+export const resolveMarketBody = z.object({
+  outcome: z.number().int().min(0).max(1),
+});
+
 // --- Treasury schemas ---
 
 export const distributeLeaderboardBody = z.object({

--- a/backend/src/services/blockchain/oracle.ts
+++ b/backend/src/services/blockchain/oracle.ts
@@ -166,6 +166,75 @@ export class OracleService extends BaseBlockchainService {
       return null;
     }
   }
+
+  /**
+   * Report the winning outcome for a market (Phase 1 of resolution)
+   * @param marketContractAddress - The contract address of the market being resolved
+   * @param outcome - The winning outcome (0 or 1)
+   * @returns Transaction hash
+   */
+  async reportOutcome(
+    marketContractAddress: string,
+    outcome: number
+  ): Promise<string> {
+    if (!this.oracleContractId) {
+      throw new Error('Oracle contract address not configured');
+    }
+
+    // Use the first available oracle keypair (usually admin)
+    const signer = this.oracleKeypairs[0];
+    if (!signer) {
+      throw new Error('No oracle signer available');
+    }
+
+    try {
+      const contract = new Contract(this.oracleContractId);
+      const sourceAccount = await this.rpcServer.getAccount(signer.publicKey());
+
+      // marketContractAddress is used as market_id in the oracle contract
+      const marketIdBuffer = Buffer.from(marketContractAddress, 'hex');
+
+      const builtTransaction = new TransactionBuilder(sourceAccount, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          contract.call(
+            'report_outcome',
+            signer.address().toScVal(),
+            nativeToScVal(marketIdBuffer, { type: 'bytes' }),
+            nativeToScVal(outcome, { type: 'u32' })
+          )
+        )
+        .setTimeout(30)
+        .build();
+
+      const preparedTransaction =
+        await this.rpcServer.prepareTransaction(builtTransaction);
+      preparedTransaction.sign(signer);
+
+      const response =
+        await this.rpcServer.sendTransaction(preparedTransaction);
+
+      if (response.status === 'PENDING') {
+        const txHash = response.hash;
+        await this.waitForTransaction(txHash, 'reportOutcome', {
+          marketContractAddress,
+          outcome,
+        });
+        return txHash;
+      } else {
+        throw new Error(`Transaction failed: ${response.status}`);
+      }
+    } catch (error) {
+      logger.error('Oracle.report_outcome() error', { error });
+      throw new Error(
+        `Failed to report outcome on blockchain: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`
+      );
+    }
+  }
 }
 
 export const oracleService = new OracleService();

--- a/backend/src/services/market.service.ts
+++ b/backend/src/services/market.service.ts
@@ -245,6 +245,35 @@ export class MarketService {
     return resolvedMarket;
   }
 
+  async reportMarketOutcome(
+    marketId: string,
+    winningOutcome: number,
+    resolutionSource: string
+  ) {
+    const market = await this.marketRepository.findById(marketId);
+    if (!market) {
+      throw new Error('Market not found');
+    }
+
+    if (market.status !== MarketStatus.CLOSED) {
+      throw new Error(`Market must be CLOSED to report outcome. Current status: ${market.status}`);
+    }
+
+    if (winningOutcome !== 0 && winningOutcome !== 1) {
+      throw new Error('Winning outcome must be 0 or 1');
+    }
+
+    // Update market status to REPORTED
+    return await this.marketRepository.updateMarketStatus(
+      marketId,
+      MarketStatus.REPORTED,
+      {
+        winningOutcome,
+        resolutionSource,
+      }
+    );
+  }
+
   async markWinningsClaimed(marketId: string, userId: string) {
     const prediction = await this.predictionRepository.findByUserAndMarket(
       userId,

--- a/contracts/contracts/boxmeout/src/oracle.rs
+++ b/contracts/contracts/boxmeout/src/oracle.rs
@@ -61,6 +61,14 @@ pub struct ChallengeResolvedEvent {
     pub slashed_amount: i128,
 }
 
+#[contractevent]
+pub struct MarketReportedEvent {
+    pub market_id: BytesN<32>,
+    pub outcome: u32,
+    pub reporter: Address,
+    pub timestamp: u64,
+}
+
 // Storage keys
 const ADMIN_KEY: &str = "admin";
 const REQUIRED_CONSENSUS_KEY: &str = "required_consensus";
@@ -569,6 +577,44 @@ impl OracleManager {
             market_id,
             final_outcome,
             timestamp: current_time,
+        }
+        .publish(&env);
+    }
+
+    /// Report winning outcome for a closed market
+    /// Phase 1 of two-phase resolution
+    pub fn report_outcome(env: Env, reporter: Address, market_id: BytesN<32>, outcome: u32) {
+        // 1. Require reporter authentication
+        reporter.require_auth();
+
+        // 2. Validate reporter is registered (trusted attestor)
+        let oracle_key = (Symbol::new(&env, "oracle"), reporter.clone());
+        let is_registered: bool = env.storage().persistent().get(&oracle_key).unwrap_or(false);
+        if !is_registered {
+            panic!("Reporter not registered");
+        }
+
+        // 3. Validate market is registered
+        let market_key = (Symbol::new(&env, MARKET_RES_TIME_KEY), market_id.clone());
+        if !env.storage().persistent().has(&market_key) {
+            panic!("Market not registered");
+        }
+
+        // 4. Validate outcome is binary (0 or 1)
+        if outcome > 1 {
+            panic!("Invalid outcome");
+        }
+
+        // 5. Store the reported outcome
+        let report_key = (Symbol::new(&env, "reported_outcome"), market_id.clone());
+        env.storage().persistent().set(&report_key, &outcome);
+
+        // 6. Emit MarketReported event
+        MarketReportedEvent {
+            market_id,
+            outcome,
+            reporter,
+            timestamp: env.ledger().timestamp(),
         }
         .publish(&env);
     }


### PR DESCRIPTION
I have successfully implemented the market resolution via oracle, following a two-phase resolution process.

Key Accomplishments
Database Schema: Added the REPORTED status to the MarketStatus enum in Prisma to represent the transition period between reporting and final resolution.
Smart Contract: Implemented a new report_outcome function in the OracleManager contract. This allows authorized oracles to submit the winning outcome for closed markets, emitting a MarketReportedEvent.
Blockchain Connectivity: Added the reportOutcome method to the OracleService in the backend, enabling the API to interact with the new contract function.
Backend Flow: Updated the OracleController so that the /resolve endpoint now handles the Phase 1 reporting process. It validates that the market is CLOSED, submits the outcome to the Stellar blockchain, and updates the database record to REPORTED.

closes #358 