### PR TITLE
feat(treasury): implement protocol fee collection endpoint (issue #28)

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -561,6 +561,7 @@ model Distribution {
 enum DistributionType {
   LEADERBOARD
   CREATOR
+  PROTOCOL_FEE
 }
 
 enum DistributionStatus {

--- a/backend/src/controllers/treasury.controller.ts
+++ b/backend/src/controllers/treasury.controller.ts
@@ -10,6 +10,29 @@ export class TreasuryController {
     this.treasuryService = new TreasuryService();
   }
 
+  async collectProtocolFees(req: AuthenticatedRequest, res: Response): Promise<void> {
+    try {
+      if (!req.user) {
+        res.status(401).json({ success: false, error: { code: 'UNAUTHORIZED', message: 'Authentication required' } });
+        return;
+      }
+
+      const { marketId } = req.params;
+      const result = await this.treasuryService.collectProtocolFees(marketId, req.user.userId);
+      res.json({ success: true, data: result });
+    } catch (error) {
+      const code = (error as any).code;
+      if (code === 'NOT_FOUND') {
+        res.status(404).json({ success: false, error: { code, message: (error as Error).message } });
+      } else if (code === 'INVALID_STATE' || code === 'EMPTY_POOL') {
+        res.status(400).json({ success: false, error: { code, message: (error as Error).message } });
+      } else {
+        (req.log || logger).error('Collect protocol fees error', { error });
+        res.status(500).json({ success: false, error: { code: 'TREASURY_ERROR', message: error instanceof Error ? error.message : 'Failed to collect fees' } });
+      }
+    }
+  }
+
   async getBalances(req: AuthenticatedRequest, res: Response): Promise<void> {
     try {
       const balances = await this.treasuryService.getBalances();

--- a/backend/src/routes/treasury.routes.ts
+++ b/backend/src/routes/treasury.routes.ts
@@ -45,6 +45,13 @@ const router: Router = Router();
  *       401:
  *         $ref: '#/components/responses/Unauthorized'
  */
+router.post(
+  '/collect/:marketId',
+  requireAuth,
+  requireAdmin,
+  (req, res) => treasuryController.collectProtocolFees(req, res)
+);
+
 router.get('/balances', requireAuth, (req, res) =>
   treasuryController.getBalances(req, res)
 );

--- a/backend/src/services/blockchain/treasury.ts
+++ b/backend/src/services/blockchain/treasury.ts
@@ -153,6 +153,34 @@ export class TreasuryService extends BaseBlockchainService {
     }
   }
 
+  async collectProtocolFees(marketId: string): Promise<{ txHash: string; amountCollected: string }> {
+    if (!this.treasuryContractId) throw new Error('Treasury contract address not configured');
+    if (!this.adminKeypair) throw new Error('ADMIN_WALLET_SECRET not configured');
+
+    const contract = new Contract(this.treasuryContractId);
+    const sourceAccount = await this.rpcServer.getAccount(this.adminKeypair.publicKey());
+
+    const builtTransaction = new TransactionBuilder(sourceAccount, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(contract.call('collect_protocol_fees', nativeToScVal(marketId, { type: 'symbol' })))
+      .setTimeout(30)
+      .build();
+
+    const preparedTransaction = await this.rpcServer.prepareTransaction(builtTransaction);
+    preparedTransaction.sign(this.adminKeypair);
+
+    const response = await this.rpcServer.sendTransaction(preparedTransaction);
+    if (response.status !== 'PENDING') throw new Error('Transaction submission failed');
+
+    const txHash = response.hash;
+    const result = await this.waitForTransaction(txHash, 'collectProtocolFees', { marketId });
+
+    const amountCollected = result && scValToNative((result as any).returnValue)?.toString() || '0';
+    return { txHash, amountCollected };
+  }
+
   async distributeCreator(
     marketId: string,
     creatorAddress: string,

--- a/backend/src/services/treasury.service.ts
+++ b/backend/src/services/treasury.service.ts
@@ -3,17 +3,48 @@ import {
   TreasuryBalances,
 } from './blockchain/treasury.js';
 import { TreasuryDistributionRepository } from '../repositories/treasury-distribution.repository.js';
-import { DistributionType, DistributionStatus } from '@prisma/client';
+import { MarketRepository } from '../repositories/market.repository.js';
+import { DistributionType, DistributionStatus, MarketStatus } from '@prisma/client';
 
 export class TreasuryService {
   private distributionRepository: TreasuryDistributionRepository;
+  private marketRepository: MarketRepository;
 
   constructor() {
     this.distributionRepository = new TreasuryDistributionRepository();
+    this.marketRepository = new MarketRepository();
   }
 
   async getBalances(): Promise<TreasuryBalances> {
     return await blockchainTreasuryService.getBalances();
+  }
+
+  async collectProtocolFees(marketId: string, initiatedBy: string) {
+    const market = await this.marketRepository.findById(marketId);
+    if (!market) throw Object.assign(new Error('Market not found'), { code: 'NOT_FOUND' });
+
+    if (market.status !== MarketStatus.RESOLVED && market.status !== MarketStatus.CANCELLED) {
+      throw Object.assign(new Error('Market is not resolved or cancelled'), { code: 'INVALID_STATE' });
+    }
+
+    const { txHash, amountCollected } = await blockchainTreasuryService.collectProtocolFees(marketId);
+
+    if (!amountCollected || amountCollected === '0') {
+      throw Object.assign(new Error('Fee pool is empty'), { code: 'EMPTY_POOL' });
+    }
+
+    const distribution = await this.distributionRepository.createDistribution({
+      distributionType: DistributionType.PROTOCOL_FEE,
+      totalAmount: parseFloat(amountCollected),
+      recipientCount: 1,
+      txHash,
+      initiatedBy,
+      metadata: { marketId },
+    });
+
+    await this.distributionRepository.updateStatus(distribution.id, DistributionStatus.CONFIRMED);
+
+    return { distributionId: distribution.id, txHash, amountCollected };
   }
 
   async distributeLeaderboard(


### PR DESCRIPTION
### What
Adds POST /treasury/collect/:marketId — an admin-only endpoint that triggers on-chain 
collection of accumulated protocol fees from a settled market to the treasury.

### Changes
- **prisma/schema.prisma** — added PROTOCOL_FEE to DistributionType enum
- **services/blockchain/treasury.ts** — added collectProtocolFees() to build, sign, and 
submit the collect_protocol_fees Soroban contract call
- **services/treasury.service.ts** — validates market state, calls blockchain service, 
records distribution in DB
- **controllers/treasury.controller.ts** — handles request/response, maps domain errors to 
correct HTTP status codes
- **routes/treasury.routes.ts** — registers route with requireAuth + requireAdmin guards

### Behaviour
| Scenario | Response |
|---|---|
| Success | 200 with { distributionId, txHash, amountCollected } |
| Market not found | 404 |
| Market not resolved/cancelled | 400 INVALID_STATE |
| Fee pool is empty | 400 EMPTY_POOL |

### Acceptance Criteria
- [x] POST /treasury/collect/:marketId (admin only)
- [x] Validates market is resolved or cancelled
- [x] Calls Stellar contract collect_protocol_fees
- [x] Records collection in DB via treasury.service.ts
- [x] Returns 200 with amount collected
- [x] Returns 400 if fee pool is empty

Closes #372 