### PR TITLE
feat(frontend): implement core betting UI, hooks, and E2E test

### DIFF
--- a/frontend/e2e/bet-flow.spec.ts
+++ b/frontend/e2e/bet-flow.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * E2E: Full bet placement flow
+ *
+ * Mocks:
+ *   - GET /api/markets          → returns a single open market
+ *   - GET /api/markets/:id      → returns the same market
+ *   - window.freighter          → simulates Freighter extension
+ *   - POST /api/tx (or Horizon) → mocked via route interception
+ */
+
+import { test, expect, Page } from '@playwright/test';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const MOCK_MARKET = {
+  market_id: 'mkt-001',
+  match_id: 'match-001',
+  fighter_a: 'Canelo Alvarez',
+  fighter_b: 'Gennady Golovkin',
+  weight_class: 'Super-Middleweight',
+  title_fight: true,
+  venue: 'T-Mobile Arena',
+  scheduled_at: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(), // 3h from now
+  status: 'open',
+  outcome: null,
+  pool_a: '500000000',   // 50 XLM
+  pool_b: '300000000',   // 30 XLM
+  pool_draw: '200000000', // 20 XLM
+  total_pool: '1000000000',
+  odds_a: 5000,
+  odds_b: 3000,
+  odds_draw: 2000,
+  fee_bps: 200,
+};
+
+const MOCK_TX_HASH = 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1';
+const MOCK_ADDRESS = 'GABC1234WXYZ5678GABC1234WXYZ5678GABC1234WXYZ5678GABC1234WXYZ';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function mockApiRoutes(page: Page) {
+  await page.route('**/api/markets', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ markets: [MOCK_MARKET], total: 1, page: 1, limit: 20 }),
+    }),
+  );
+
+  await page.route(`**/api/markets/${MOCK_MARKET.market_id}`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_MARKET),
+    }),
+  );
+
+  // Mock any Stellar/Horizon tx submission
+  await page.route('**/transactions', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ hash: MOCK_TX_HASH, successful: true }),
+    }),
+  );
+}
+
+async function mockFreighter(page: Page) {
+  await page.addInitScript((address) => {
+    (window as any).freighter = {
+      isConnected: () => Promise.resolve(true),
+      getPublicKey: () => Promise.resolve(address),
+      signTransaction: (_xdr: string) => Promise.resolve('SIGNED_XDR_PLACEHOLDER'),
+      getNetwork: () => Promise.resolve('TESTNET'),
+    };
+  }, MOCK_ADDRESS);
+}
+
+// ── Test ──────────────────────────────────────────────────────────────────────
+
+test('complete bet placement flow', async ({ page }) => {
+  await mockApiRoutes(page);
+  await mockFreighter(page);
+
+  // 1. Navigate to home — verify market list loads
+  await page.goto('/');
+  await expect(page.getByText('Canelo Alvarez')).toBeVisible();
+  await expect(page.getByText('Gennady Golovkin')).toBeVisible();
+
+  // 2. Click market card — verify detail page loads
+  await page.getByRole('link', { name: /Canelo Alvarez/i }).first().click();
+  await page.waitForURL(`**/markets/${MOCK_MARKET.market_id}`);
+  await expect(page.getByText('Canelo Alvarez')).toBeVisible();
+  await expect(page.getByText('Gennady Golovkin')).toBeVisible();
+
+  // 3. Connect wallet — mock Freighter connection
+  await page.getByRole('button', { name: /connect wallet/i }).first().click();
+  // Wait for address to appear (truncated: first4...last4)
+  await expect(page.getByText(/GABC.*WXYZ/i)).toBeVisible({ timeout: 5000 });
+
+  // 4. Select Fighter A in BetPanel
+  await page.getByRole('button', { name: /Canelo Alvarez/i }).click();
+
+  // 5. Enter 10 XLM
+  await page.getByPlaceholder('0.00').fill('10');
+
+  // 6. Verify estimated payout appears
+  await expect(page.getByText(/Est\. payout/i)).toBeVisible();
+  await expect(page.getByText(/XLM/)).toBeVisible();
+
+  // 7. Click "Place Bet" — verify confirm modal opens
+  await page.getByRole('button', { name: /place bet/i }).click();
+  await expect(page.getByRole('heading', { name: /confirm bet/i })).toBeVisible();
+  await expect(page.getByText('Canelo Alvarez')).toBeVisible();
+  await expect(page.getByText('10 XLM')).toBeVisible();
+
+  // 8. Click "Confirm Bet" — mock Stellar tx submission
+  await page.getByRole('button', { name: /confirm bet/i }).click();
+
+  // 9. Verify TxStatusToast shows success with tx hash
+  await expect(page.getByText(/bet placed/i)).toBeVisible({ timeout: 10000 });
+  await expect(page.getByText(MOCK_TX_HASH.slice(0, 12))).toBeVisible();
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  retries: 0,
+  use: {
+    baseURL: process.env.BASE_URL ?? 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+});

--- a/frontend/src/components/bet/BetConfirmModal.tsx
+++ b/frontend/src/components/bet/BetConfirmModal.tsx
@@ -1,7 +1,7 @@
-// ============================================================
-// BOXMEOUT — BetConfirmModal Component
-// ============================================================
+'use client';
 
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import type { BetSide } from '../../types';
 
 interface BetConfirmModalProps {
@@ -16,20 +16,49 @@ interface BetConfirmModalProps {
   onCancel: () => void;
 }
 
-/**
- * Modal dialog shown before a bet is submitted to the blockchain.
- *
- * Must display:
- *   - Fighter chosen (translated from side to name)
- *   - Bet amount in XLM
- *   - Platform fee in XLM and percentage
- *   - Estimated payout in XLM (gross)
- *   - "Confirm Bet" button → calls onConfirm()
- *   - "Cancel" button → calls onCancel()
- *
- * Rendered as a portal over the page content.
- * Closes on backdrop click or Escape key.
- */
-export function BetConfirmModal(props: BetConfirmModalProps): JSX.Element {
-  // TODO: implement
+const SIDE_LABEL: Record<BetSide, (a: string, b: string) => string> = {
+  fighter_a: (a) => a,
+  fighter_b: (_, b) => b,
+  draw: () => 'Draw',
+};
+
+export function BetConfirmModal({
+  isOpen, fighter_a, fighter_b, side, amount_xlm, estimated_payout_xlm, fee_bps, onConfirm, onCancel,
+}: BetConfirmModalProps): JSX.Element {
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && onCancel();
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return <></>;
+
+  const feeXlm = amount_xlm * (fee_bps / 10000);
+  const chosen = SIDE_LABEL[side](fighter_a, fighter_b);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-gray-900 rounded-xl p-6 w-full max-w-sm space-y-4 text-white"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-bold">Confirm Bet</h2>
+        <dl className="space-y-2 text-sm">
+          <div className="flex justify-between"><dt className="text-gray-400">Fighter</dt><dd>{chosen}</dd></div>
+          <div className="flex justify-between"><dt className="text-gray-400">Amount</dt><dd>{amount_xlm} XLM</dd></div>
+          <div className="flex justify-between"><dt className="text-gray-400">Platform fee ({fee_bps / 100}%)</dt><dd>{feeXlm.toFixed(4)} XLM</dd></div>
+          <div className="flex justify-between font-semibold"><dt className="text-gray-400">Est. payout</dt><dd>{estimated_payout_xlm.toFixed(4)} XLM</dd></div>
+        </dl>
+        <div className="flex gap-3 pt-2">
+          <button onClick={onCancel} className="flex-1 py-2 rounded-lg border border-gray-600 hover:bg-gray-800">Cancel</button>
+          <button onClick={onConfirm} className="flex-1 py-2 rounded-lg bg-amber-500 hover:bg-amber-400 font-semibold text-black">Confirm Bet</button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
 }

--- a/frontend/src/components/bet/BetPanel.tsx
+++ b/frontend/src/components/bet/BetPanel.tsx
@@ -1,34 +1,130 @@
-// ============================================================
-// BOXMEOUT — BetPanel Component
-// Full bet placement UI shown on the Market Detail page.
-// ============================================================
+'use client';
 
-import type { Market } from '../../types';
+import { useState } from 'react';
+import type { BetSide, Market } from '../../types';
+import { useBet } from '../../hooks/useBet';
+import { useWallet } from '../../hooks/useWallet';
+import { BetConfirmModal } from './BetConfirmModal';
+import { TxStatusToast } from '../ui/TxStatusToast';
+import { useAppStore } from '../../store';
 
 interface BetPanelProps {
   market: Market;
 }
 
-/**
- * Bet placement panel. Uses the useBet hook internally.
- *
- * Must render:
- *   1. Three toggle buttons: [Fighter A] [Draw] [Fighter B]
- *      — selected button highlighted; reflects useBet.side state
- *   2. Amount input (XLM) with min/max hints from market.config
- *   3. Estimated payout display (updates live as side/amount changes)
- *   4. Platform fee line (e.g. "Fee: 2%")
- *   5. Submit button — disabled while isSubmitting or amount invalid
- *   6. TxStatusToast shown after submission
- *
- * If wallet is not connected:
- *   - Hide the form
- *   - Show a "Connect Wallet to Bet" prompt button
- *
- * If market.status !== "open":
- *   - Show status-appropriate message (e.g. "Betting is closed")
- *   - Disable the form
- */
+const SIDES: { value: BetSide; label: (a: string, b: string) => string }[] = [
+  { value: 'fighter_a', label: (a) => a },
+  { value: 'draw', label: () => 'Draw' },
+  { value: 'fighter_b', label: (_, b) => b },
+];
+
 export function BetPanel({ market }: BetPanelProps): JSX.Element {
-  // TODO: implement
+  const { isConnected, connect } = useWallet();
+  const { side, setSide, amount, setAmount, estimatedPayout, isSubmitting, txStatus, submitBet, reset } = useBet(market);
+  const setTxStatus = useAppStore((s) => s.setTxStatus);
+  const [showModal, setShowModal] = useState(false);
+
+  const amountNum = parseFloat(amount);
+  const isAmountValid = !isNaN(amountNum) && amountNum > 0;
+  const canSubmit = isConnected && !!side && isAmountValid && !isSubmitting && market.status === 'open';
+
+  if (!isConnected) {
+    return (
+      <div className="rounded-xl bg-gray-900 p-6 text-center space-y-3">
+        <p className="text-gray-400 text-sm">Connect your wallet to place a bet</p>
+        <button onClick={connect} className="w-full py-2 rounded-lg bg-amber-500 hover:bg-amber-400 font-semibold text-black">
+          Connect Wallet to Bet
+        </button>
+      </div>
+    );
+  }
+
+  if (market.status !== 'open') {
+    return (
+      <div className="rounded-xl bg-gray-900 p-6 text-center">
+        <p className="text-gray-400 font-semibold">Betting is closed</p>
+        <p className="text-gray-500 text-sm mt-1 capitalize">Market is {market.status}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl bg-gray-900 p-6 space-y-4 text-white">
+      {/* Side selector */}
+      <div className="flex gap-2">
+        {SIDES.map(({ value, label }) => (
+          <button
+            key={value}
+            onClick={() => setSide(value)}
+            className={`flex-1 py-2 rounded-lg text-sm font-semibold transition-colors ${
+              side === value
+                ? 'bg-amber-500 text-black'
+                : 'bg-gray-800 text-gray-300 hover:bg-gray-700'
+            }`}
+          >
+            {label(market.fighter_a, market.fighter_b)}
+          </button>
+        ))}
+      </div>
+
+      {/* Amount input */}
+      <div>
+        <label className="block text-xs text-gray-400 mb-1">Amount (XLM)</label>
+        <input
+          type="number"
+          min="1"
+          step="0.01"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder="0.00"
+          className="w-full bg-gray-800 rounded-lg px-3 py-2 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+        />
+        <p className="text-xs text-gray-500 mt-1">Min: 1 XLM</p>
+      </div>
+
+      {/* Payout preview */}
+      <div className="bg-gray-800 rounded-lg px-4 py-3 space-y-1 text-sm">
+        <div className="flex justify-between text-gray-400">
+          <span>Platform fee</span>
+          <span>{market.fee_bps / 100}%</span>
+        </div>
+        <div className="flex justify-between font-semibold">
+          <span>Est. payout</span>
+          <span>{estimatedPayout != null ? `${estimatedPayout.toFixed(4)} XLM` : '—'}</span>
+        </div>
+      </div>
+
+      {/* Submit */}
+      <button
+        disabled={!canSubmit}
+        onClick={() => setShowModal(true)}
+        className="w-full py-2 rounded-lg bg-amber-500 hover:bg-amber-400 font-semibold text-black disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {isSubmitting ? 'Placing Bet…' : 'Place Bet'}
+      </button>
+
+      <BetConfirmModal
+        isOpen={showModal}
+        fighter_a={market.fighter_a}
+        fighter_b={market.fighter_b}
+        side={side ?? 'fighter_a'}
+        amount_xlm={amountNum || 0}
+        estimated_payout_xlm={estimatedPayout ?? 0}
+        fee_bps={market.fee_bps}
+        onCancel={() => setShowModal(false)}
+        onConfirm={async () => {
+          setShowModal(false);
+          await submitBet();
+        }}
+      />
+
+      <TxStatusToast
+        txStatus={txStatus}
+        onDismiss={() => {
+          setTxStatus({ hash: null, status: 'idle', error: null });
+          if (txStatus.status === 'success') reset();
+        }}
+      />
+    </div>
+  );
 }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,19 +1,73 @@
-// ============================================================
-// BOXMEOUT — Header Component
-// ============================================================
+'use client';
 
-/**
- * Site-wide top navigation bar.
- *
- * Must render:
- *   - Left: BOXMEOUT logo (links to /)
- *   - Center: nav links — Home (/), Portfolio (/portfolio)
- *   - Right: WalletButton component
- *   - Network indicator badge (Testnet / Mainnet) from env config
- *
- * Sticky positioned at top of viewport.
- * Collapses nav links to a hamburger menu on mobile.
- */
+import Link from 'next/link';
+import { useState, useEffect } from 'react';
+import { WalletButton } from './WalletButton';
+
+const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet';
+const IS_MAINNET = NETWORK === 'mainnet';
+const BANNER_KEY = 'boxmeout_mainnet_banner_dismissed';
+
 export function Header(): JSX.Element {
-  // TODO: implement
+  const [bannerDismissed, setBannerDismissed] = useState(true);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    if (IS_MAINNET) {
+      setBannerDismissed(sessionStorage.getItem(BANNER_KEY) === '1');
+    }
+  }, []);
+
+  const dismissBanner = () => {
+    sessionStorage.setItem(BANNER_KEY, '1');
+    setBannerDismissed(true);
+  };
+
+  return (
+    <>
+      {IS_MAINNET && !bannerDismissed && (
+        <div className="bg-red-600 text-white text-sm text-center py-2 px-4 flex items-center justify-center gap-3">
+          <span>⚠️ You are betting with real XLM on mainnet</span>
+          <button onClick={dismissBanner} className="ml-auto text-white/80 hover:text-white font-bold">✕</button>
+        </div>
+      )}
+      <header className="sticky top-0 z-40 bg-gray-950 border-b border-gray-800">
+        <div className="max-w-6xl mx-auto px-4 h-14 flex items-center gap-6">
+          <Link href="/" className="font-black text-amber-500 text-xl tracking-tight">BOXMEOUT</Link>
+
+          {/* Desktop nav */}
+          <nav className="hidden md:flex gap-4 text-sm text-gray-300">
+            <Link href="/" className="hover:text-white">Home</Link>
+            <Link href="/portfolio" className="hover:text-white">Portfolio</Link>
+          </nav>
+
+          <div className="ml-auto flex items-center gap-3">
+            {/* Network badge */}
+            <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${IS_MAINNET ? 'bg-green-600 text-white' : 'bg-amber-500/20 text-amber-400'}`}>
+              {IS_MAINNET ? 'MAINNET' : 'TESTNET'}
+            </span>
+
+            <WalletButton />
+
+            {/* Mobile hamburger */}
+            <button
+              className="md:hidden text-gray-400 hover:text-white"
+              onClick={() => setMenuOpen((o) => !o)}
+              aria-label="Toggle menu"
+            >
+              ☰
+            </button>
+          </div>
+        </div>
+
+        {/* Mobile nav */}
+        {menuOpen && (
+          <nav className="md:hidden bg-gray-950 border-t border-gray-800 px-4 py-3 flex flex-col gap-3 text-sm text-gray-300">
+            <Link href="/" onClick={() => setMenuOpen(false)} className="hover:text-white">Home</Link>
+            <Link href="/portfolio" onClick={() => setMenuOpen(false)} className="hover:text-white">Portfolio</Link>
+          </nav>
+        )}
+      </header>
+    </>
+  );
 }

--- a/frontend/src/components/ui/TxStatusToast.tsx
+++ b/frontend/src/components/ui/TxStatusToast.tsx
@@ -1,35 +1,62 @@
-// ============================================================
-// BOXMEOUT — TxStatusToast Component
-// ============================================================
+'use client';
 
+import { useEffect } from 'react';
 import type { TxStatus } from '../../types';
 
 interface TxStatusToastProps {
   txStatus: TxStatus;
-  /** Called when user dismisses the toast */
   onDismiss: () => void;
 }
 
-/**
- * Toast notification for Stellar transaction lifecycle.
- *
- * States:
- *   idle     → render nothing
- *   pending  → spinner + "Transaction pending..."
- *   success  → green check + "Bet placed!" + Stellar Explorer link
- *   error    → red X + error message + retry suggestion
- *
- * Auto-dismisses after 6 seconds on success.
- * Stays visible until dismissed on error.
- * Renders as a fixed overlay at bottom-right of screen.
- *
- * Explorer link format:
- *   Testnet: https://stellar.expert/explorer/testnet/tx/{hash}
- *   Mainnet: https://stellar.expert/explorer/public/tx/{hash}
- */
-export function TxStatusToast({
-  txStatus,
-  onDismiss,
-}: TxStatusToastProps): JSX.Element {
-  // TODO: implement
+const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'mainnet' ? 'public' : 'testnet';
+
+export function TxStatusToast({ txStatus, onDismiss }: TxStatusToastProps): JSX.Element {
+  useEffect(() => {
+    if (txStatus.status !== 'success') return;
+    const id = setTimeout(onDismiss, 6000);
+    return () => clearTimeout(id);
+  }, [txStatus.status, onDismiss]);
+
+  if (txStatus.status === 'idle') return <></>;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 max-w-sm w-full bg-gray-900 text-white rounded-xl shadow-xl p-4 flex items-start gap-3">
+      {txStatus.status === 'pending' && (
+        <>
+          <span className="animate-spin text-xl">⏳</span>
+          <p className="text-sm">Transaction pending…</p>
+        </>
+      )}
+      {txStatus.status === 'success' && (
+        <>
+          <span className="text-green-400 text-xl">✓</span>
+          <div className="flex-1 text-sm">
+            <p className="font-semibold">Bet placed!</p>
+            {txStatus.hash && (
+              <a
+                href={`https://stellar.expert/explorer/${NETWORK}/tx/${txStatus.hash}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-amber-400 underline break-all"
+              >
+                {txStatus.hash.slice(0, 12)}…
+              </a>
+            )}
+          </div>
+          <button onClick={onDismiss} className="text-gray-400 hover:text-white">✕</button>
+        </>
+      )}
+      {txStatus.status === 'error' && (
+        <>
+          <span className="text-red-400 text-xl">✕</span>
+          <div className="flex-1 text-sm">
+            <p className="font-semibold text-red-400">Transaction failed</p>
+            <p className="text-gray-300">{txStatus.error}</p>
+            <p className="text-gray-500 text-xs mt-1">Please try again.</p>
+          </div>
+          <button onClick={onDismiss} className="text-gray-400 hover:text-white">✕</button>
+        </>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/hooks/useBet.ts
+++ b/frontend/src/hooks/useBet.ts
@@ -1,37 +1,78 @@
 // ============================================================
 // BOXMEOUT — useBet Hook
-// Manages the full bet placement flow for a single market.
 // ============================================================
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import type { BetSide, Market, TxStatus } from '../types';
+import { submitBet } from '../services/wallet';
+import { useAppStore } from '../store';
 
 export interface UseBetResult {
   side: BetSide | null;
   setSide: (side: BetSide) => void;
   amount: string;
   setAmount: (amount: string) => void;
-  /** Estimated payout in XLM; null if inputs are incomplete */
   estimatedPayout: number | null;
   isSubmitting: boolean;
   txStatus: TxStatus;
   error: string | null;
-  /** Submits the bet. Resolves when tx is confirmed or rejects on error. */
   submitBet: () => Promise<void>;
-  /** Resets form to initial state */
   reset: () => void;
 }
 
-/**
- * Manages all state for placing a single bet on a market.
- *
- * Behavior:
- *   - estimatedPayout recalculates whenever side or amount changes
- *     by calling fetchMarketById and running the parimutuel formula locally
- *   - submitBet calls wallet.submitBet() and tracks TxStatus
- *   - Error messages are user-readable (not raw errors)
- *   - reset() clears form after a successful bet
- */
+const FEE_DIVISOR = 10000;
+
+function calcPayout(market: Market, side: BetSide, amountXlm: number): number | null {
+  if (!amountXlm || amountXlm <= 0) return null;
+  const poolA = Number(market.pool_a) / 1e7;
+  const poolB = Number(market.pool_b) / 1e7;
+  const poolDraw = Number(market.pool_draw) / 1e7;
+  const sidePool = side === 'fighter_a' ? poolA : side === 'fighter_b' ? poolB : poolDraw;
+  const total = poolA + poolB + poolDraw + amountXlm;
+  const newSidePool = sidePool + amountXlm;
+  if (newSidePool === 0) return null;
+  const gross = (amountXlm / newSidePool) * total;
+  return gross * (1 - market.fee_bps / FEE_DIVISOR);
+}
+
 export function useBet(market: Market): UseBetResult {
-  // TODO: implement
+  const [side, setSide] = useState<BetSide | null>(null);
+  const [amount, setAmount] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { lastTxStatus, setTxStatus, walletAddress } = useAppStore();
+
+  const estimatedPayout = useMemo(() => {
+    if (!side) return null;
+    const xlm = parseFloat(amount);
+    return calcPayout(market, side, xlm);
+  }, [side, amount, market]);
+
+  const submit = useCallback(async () => {
+    if (!side || !walletAddress) return;
+    const xlm = parseFloat(amount);
+    if (!xlm || xlm <= 0) return;
+    setError(null);
+    setIsSubmitting(true);
+    setTxStatus({ hash: null, status: 'pending', error: null });
+    try {
+      const hash = await submitBet(market.market_id, side, xlm);
+      setTxStatus({ hash, status: 'success', error: null });
+    } catch (e: any) {
+      const msg = e?.message ?? 'Transaction failed';
+      setError(msg);
+      setTxStatus({ hash: null, status: 'error', error: msg });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [side, amount, market, walletAddress, setTxStatus]);
+
+  const reset = useCallback(() => {
+    setSide(null);
+    setAmount('');
+    setError(null);
+    setTxStatus({ hash: null, status: 'idle', error: null });
+  }, [setTxStatus]);
+
+  return { side, setSide, amount, setAmount, estimatedPayout, isSubmitting, txStatus: lastTxStatus, error, submitBet: submit, reset };
 }

--- a/frontend/src/hooks/useMarketCountdown.ts
+++ b/frontend/src/hooks/useMarketCountdown.ts
@@ -17,8 +17,29 @@ import { useState, useEffect } from 'react';
  *
  * @param scheduled_at  ISO 8601 timestamp string of fight start
  */
+const RESOLUTION_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+function compute(scheduled_at_ms: number): string {
+  const now = Date.now();
+  if (now >= scheduled_at_ms + RESOLUTION_WINDOW_MS) return 'ENDED';
+  if (now >= scheduled_at_ms) return 'LIVE';
+  const diff = Math.floor((scheduled_at_ms - now) / 1000);
+  const h = Math.floor(diff / 3600);
+  const m = Math.floor((diff % 3600) / 60);
+  const s = diff % 60;
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
 export function useMarketCountdown(scheduled_at: string): string {
-  // TODO: implement
-  // Hint: use Date.now() for current time
-  //       clear interval in useEffect cleanup
+  const ms = new Date(scheduled_at).getTime();
+  const [label, setLabel] = useState(() => compute(ms));
+
+  useEffect(() => {
+    const id = setInterval(() => setLabel(compute(ms)), 1000);
+    return () => clearInterval(id);
+  }, [ms]);
+
+  return label;
 }

--- a/frontend/src/hooks/useWallet.ts
+++ b/frontend/src/hooks/useWallet.ts
@@ -1,10 +1,6 @@
-// ============================================================
-// BOXMEOUT — useWallet Hook
-// Global wallet state. Use this hook everywhere in the app
-// instead of calling wallet.ts functions directly.
-// ============================================================
-
 import { useState, useEffect, useCallback } from 'react';
+import { connectWallet, disconnectWallet, getConnectedAddress, getWalletBalance } from '../services/wallet';
+import { useAppStore } from '../store';
 
 export interface UseWalletResult {
   address: string | null;
@@ -16,16 +12,47 @@ export interface UseWalletResult {
   disconnect: () => void;
 }
 
-/**
- * Manages wallet connection state for the entire app.
- * On mount: reads stored address from localStorage and refreshes balance.
- * Exposes connect() and disconnect() actions.
- *
- * Stores connected address in localStorage key "boxmeout_wallet_address"
- * so the connection persists across page refreshes.
- */
+const STORAGE_KEY = 'boxmeout_wallet_address';
+
 export function useWallet(): UseWalletResult {
-  // TODO: implement
-  // Hint: call connectWallet() on connect(), then fetch balance
-  //       read localStorage on mount to auto-restore prior session
+  const { walletAddress, walletBalance, isConnecting, setWallet, clearWallet } = useAppStore();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = getConnectedAddress();
+    if (stored) {
+      getWalletBalance().then((bal) => setWallet(stored, bal)).catch(() => {});
+    }
+  }, []);
+
+  const connect = useCallback(async () => {
+    setError(null);
+    useAppStore.setState({ isConnecting: true });
+    try {
+      const address = await connectWallet();
+      const balance = await getWalletBalance();
+      localStorage.setItem(STORAGE_KEY, address);
+      setWallet(address, balance);
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to connect wallet');
+    } finally {
+      useAppStore.setState({ isConnecting: false });
+    }
+  }, [setWallet]);
+
+  const disconnect = useCallback(() => {
+    disconnectWallet();
+    localStorage.removeItem(STORAGE_KEY);
+    clearWallet();
+  }, [clearWallet]);
+
+  return {
+    address: walletAddress,
+    balance: walletBalance,
+    isConnected: !!walletAddress,
+    isConnecting,
+    error,
+    connect,
+    disconnect,
+  };
 }

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -32,14 +32,15 @@ interface AppState {
   setTxStatus: (status: TxStatus) => void;
 }
 
-/**
- * Creates the global Zustand store.
- *
- * Initial state:
- *   walletAddress = null
- *   network = "testnet"
- *   lastTxStatus = { hash: null, status: "idle", error: null }
- */
 export const useAppStore = create<AppState>((set) => ({
-  // TODO: implement initial state and all action implementations
+  walletAddress: null,
+  walletBalance: null,
+  isConnecting: false,
+  network: (process.env.NEXT_PUBLIC_STELLAR_NETWORK as Network) ?? 'testnet',
+  lastTxStatus: { hash: null, status: 'idle', error: null },
+
+  setWallet: (address, balance) => set({ walletAddress: address, walletBalance: balance }),
+  clearWallet: () => set({ walletAddress: null, walletBalance: null }),
+  setNetwork: (network) => set({ network }),
+  setTxStatus: (status) => set({ lastTxStatus: status }),
 }));


### PR DESCRIPTION
closes #580 
closes #595 
closes #601  
closes #576 



## Hooks

### useMarketCountdown
- Computes live countdown string from a scheduled_at ISO timestamp
- Format: Xh Ym Zs → Ym Zs (when h=0) → Zs (when h=m=0)
- Transitions: LIVE when now ∈ [scheduled_at, scheduled_at+24h), then ENDED
- setInterval(1000) with cleanup on unmount — no memory leak

### useWallet
- Restores wallet session from localStorage (key: boxmeout_wallet_address) on mount
- connect() calls connectWallet() + getWalletBalance(), syncs to Zustand store
- disconnect() clears localStorage and Zustand wallet state

### useBet
- Parimutuel estimated payout via useMemo: (stake/newSidePool)*total*(1-fee_bps/10000)
- submitBet() drives TxStatus through pending → success/error in global store
- reset() clears form state after successful submission

## Store (Zustand)
- Implements all slices: wallet (address, balance, isConnecting), network, lastTxStatus
- Network seeded from NEXT_PUBLIC_STELLAR_NETWORK env var (defaults to testnet)

## Components

### BetPanel
- Fighter A / Draw / Fighter B toggle buttons with amber highlight on selection
- Amount input (XLM) with live payout preview and platform fee display
- Submit button disabled when: wallet not connected, no side selected, invalid amount, isSubmitting, or market.status !== open
- Shows Connect Wallet prompt when disconnected
- Shows Betting is closed message when market is not open
- Wires BetConfirmModal + TxStatusToast into the full bet flow

### BetConfirmModal
- Portal rendered over document.body
- Closes on backdrop click or Escape key
- Displays: chosen fighter, bet amount, platform fee (XLM + %), estimated payout
- Confirm Bet → triggers submitBet(); Cancel → closes modal

### TxStatusToast
- idle: renders nothing
- pending: spinner + Transaction pending...
- success: green check + Bet placed! + Stellar Explorer link; auto-dismisses after 6s
- error: red X + error message + retry hint; stays until manually dismissed
- Explorer URL: testnet or mainnet based on NEXT_PUBLIC_STELLAR_NETWORK

### Header
- Sticky top nav: logo (links /), Home + Portfolio nav links, WalletButton
- Network badge: TESTNET (amber) when testnet, MAINNET (green) when mainnet
- Dismissable red banner on mainnet: You are betting with real XLM on mainnet
- Banner dismiss state stored in sessionStorage — reappears on new browser session
- Mobile hamburger menu collapses nav links on small screens

## E2E Test (Playwright)
- playwright.config.ts targeting localhost:3000 (configurable via BASE_URL env)
- e2e/bet-flow.spec.ts covers the complete bet placement flow:
  1. Home page loads with market list
  2. Click market card → detail page
  3. Connect Wallet (Freighter mocked via addInitScript — no extension required)
  4. Select Fighter A
  5. Enter 10 XLM
  6. Verify estimated payout appears
  7. Click Place Bet → confirm modal opens with correct details
  8. Click Confirm Bet (Stellar tx mocked via route interception — no real network)
  9. TxStatusToast shows success with tx hash

## Closes

Closes #

## What this PR does

<!-- One paragraph. What did you implement? Do not explain how — the code does that. -->

## Testing

<!-- How did you verify this works? What test cases did you add? -->

## Screenshots (frontend changes only)

<!-- Add before/after screenshots or a short screen recording. -->

## Checklist

- [ ] I have read `docs/contributing.md`
- [ ] My code follows the naming conventions in the guidelines
- [ ] I have added or updated tests for my changes
- [ ] All tests pass locally (`cargo test` / `npm test`)
- [ ] Lint passes (`cargo clippy` / `npm run lint`)
- [ ] No `console.log` or `unwrap()` left in production paths
- [ ] No secrets committed
