### PR TITLE
Feat/issue wallet and create market

### DIFF
--- a/frontend/src/app/create/page.tsx
+++ b/frontend/src/app/create/page.tsx
@@ -1,35 +1,181 @@
-// ============================================================
-// BOXMEOUT — Create Market Page (/create)
-// Admin-only. Guarded by admin wallet address check.
-// ============================================================
+'use client';
 
-/**
- * Admin form for creating a new boxing market.
- *
- * Form fields:
- *   - Match ID (text, unique, e.g. "FURY-USYK-2025-MAY")
- *   - Fighter A name (text)
- *   - Fighter B name (text)
- *   - Weight class (select)
- *   - Venue (text)
- *   - Title Fight (checkbox)
- *   - Scheduled At (datetime-local)
- *   - Min Bet (XLM, number)
- *   - Max Bet (XLM, number)
- *   - Fee % (number, 0–10)
- *   - Lock Before (minutes before fight start to close bets)
- *
- * On submit:
- *   1. Validate all fields with Zod
- *   2. Convert XLM values to stroops
- *   3. Call wallet.submitBet() with create_market args (reuse invokeContract)
- *   4. Show TxStatusToast
- *   5. Redirect to new market detail page on success
- *
- * Access guard:
- *   - If wallet not connected → show connect prompt
- *   - If connected address is not in ADMIN_ADDRESSES env list → show 403 message
- */
-export default function CreateMarketPage(): JSX.Element {
-  // TODO: implement
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { getConnectedAddress, createMarket } from '@/services/wallet';
+import { TxStatusToast } from '@/components/ui/TxStatusToast';
+import type { TxStatus } from '@/types';
+
+const ADMIN_ADDRESSES = (
+  process.env.NEXT_PUBLIC_ADMIN_ADDRESSES ?? ''
+).split(',').map(a => a.trim()).filter(Boolean);
+
+const WEIGHT_CLASSES = [
+  'Heavyweight',
+  'Cruiserweight',
+  'Light Heavyweight',
+  'Super Middleweight',
+  'Middleweight',
+  'Super Welterweight',
+  'Welterweight',
+  'Super Lightweight',
+  'Lightweight',
+  'Super Featherweight',
+  'Featherweight',
+  'Super Bantamweight',
+  'Bantamweight',
+  'Super Flyweight',
+  'Flyweight',
+];
+
+export default function CreateMarketPage() {
+  const router = useRouter();
+  const [txStatus, setTxStatus] = useState<TxStatus>({
+    hash: null,
+    status: 'idle',
+    error: null,
+  });
+
+  const connectedAddress = getConnectedAddress();
+  const isAdmin = connectedAddress && ADMIN_ADDRESSES.includes(connectedAddress);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const data = new FormData(form);
+
+    const matchId = data.get('matchId') as string;
+    const fighterA = data.get('fighterA') as string;
+    const fighterB = data.get('fighterB') as string;
+    const weightClass = data.get('weightClass') as string;
+    const venue = data.get('venue') as string;
+    const titleFight = data.get('titleFight') === 'on';
+    const scheduledAt = data.get('scheduledAt') as string;
+    const minBet = parseFloat(data.get('minBet') as string);
+    const maxBet = parseFloat(data.get('maxBet') as string);
+    const feePct = parseFloat(data.get('feePct') as string);
+    const lockBefore = parseInt(data.get('lockBefore') as string, 10);
+
+    if (!matchId || !fighterA || !fighterB || !weightClass || !venue || !scheduledAt) {
+      setTxStatus({ hash: null, status: 'error', error: 'All fields required' });
+      return;
+    }
+    if (minBet <= 0 || maxBet <= 0 || maxBet < minBet) {
+      setTxStatus({ hash: null, status: 'error', error: 'Invalid bet limits' });
+      return;
+    }
+    if (feePct < 0 || feePct > 10) {
+      setTxStatus({ hash: null, status: 'error', error: 'Fee must be 0–10%' });
+      return;
+    }
+
+    setTxStatus({ hash: null, status: 'pending', error: null });
+
+    try {
+      const hash = await createMarket({
+        matchId,
+        fighterA,
+        fighterB,
+        weightClass,
+        venue,
+        titleFight,
+        scheduledAt: new Date(scheduledAt).toISOString(),
+        minBetXlm: minBet,
+        maxBetXlm: maxBet,
+        feeBps: Math.round(feePct * 100),
+        lockBeforeMinutes: lockBefore,
+      });
+
+      setTxStatus({ hash, status: 'success', error: null });
+      setTimeout(() => router.push(`/markets/${matchId}`), 2000);
+    } catch (err: any) {
+      setTxStatus({ hash: null, status: 'error', error: err.message });
+    }
+  };
+
+  if (!connectedAddress) {
+    return (
+      <div className="max-w-2xl mx-auto p-8 text-center">
+        <h1 className="text-2xl font-bold mb-4">Create Market</h1>
+        <p className="text-gray-400">Connect your wallet to continue</p>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="max-w-2xl mx-auto p-8 text-center">
+        <h1 className="text-2xl font-bold mb-4">Access Denied</h1>
+        <p className="text-gray-400">Admin access required</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-8">
+      <h1 className="text-3xl font-bold mb-6">Create Boxing Market</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">Match ID</label>
+          <input name="matchId" type="text" required className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded" />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Fighter A</label>
+            <input name="fighterA" type="text" required className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Fighter B</label>
+            <input name="fighterB" type="text" required className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded" />
+          </div>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Weight Class</label>
+          <select name="weightClass" required className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded">
+            {WEIGHT_CLASSES.map(wc => <option key={wc} value={wc}>{wc}</option>)}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Venue</label>
+          <input name="venue" type="text" required className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded" />
+        </div>
+        <div className="flex items-center gap-2">
+          <input name="titleFight" type="checkbox" className="w-4 h-4" />
+          <label className="text-sm font-medium">Title Fight</label>
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1">Scheduled At</label>
+          <input name="scheduledAt" type="datetime-local" required className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded" />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Min Bet (XLM)</label>
+            <input name="minBet" type="number" step="0.01" required className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Max Bet (XLM)</label>
+            <input name="maxBet" type="number" step="0.01" required className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded" />
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Fee % (0–10)</label>
+            <input name="feePct" type="number" step="0.1" min="0" max="10" required className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Lock Before (minutes)</label>
+            <input name="lockBefore" type="number" min="0" required className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded" />
+          </div>
+        </div>
+        <button
+          type="submit"
+          disabled={txStatus.status === 'pending'}
+          className="w-full py-3 bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 rounded font-semibold"
+        >
+          {txStatus.status === 'pending' ? 'Creating...' : 'Create Market'}
+        </button>
+      </form>
+      <TxStatusToast txStatus={txStatus} onDismiss={() => setTxStatus({ hash: null, status: 'idle', error: null })} />
+    </div>
+  );
 }

--- a/frontend/src/services/wallet.ts
+++ b/frontend/src/services/wallet.ts
@@ -4,7 +4,79 @@
 // Contributors: implement every function marked TODO.
 // ============================================================
 
-import type { BetSide, TxStatus } from '../types';
+import {
+  Contract,
+  Networks,
+  SorobanRpc,
+  TransactionBuilder,
+  BASE_FEE,
+  nativeToScVal,
+  xdr,
+} from '@stellar/stellar-sdk';
+import type { BetSide } from '../types';
+
+const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet';
+const HORIZON_URL =
+  process.env.NEXT_PUBLIC_HORIZON_URL ?? 'https://horizon-testnet.stellar.org';
+const SOROBAN_RPC_URL =
+  NETWORK === 'mainnet'
+    ? 'https://soroban-rpc.stellar.org'
+    : 'https://soroban-testnet.stellar.org';
+const NETWORK_PASSPHRASE =
+  NETWORK === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
+
+const LS_KEY = 'boxmeout_wallet_address';
+
+async function buildAndSubmit(
+  contractAddress: string,
+  method: string,
+  args: xdr.ScVal[],
+): Promise<string> {
+  const address = getConnectedAddress();
+  if (!address) throw new Error('WalletNotConnected');
+
+  const server = new SorobanRpc.Server(SOROBAN_RPC_URL);
+  const account = await server.getAccount(address);
+  const contract = new Contract(contractAddress);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const preparedTx = await server.prepareTransaction(tx);
+  const txXdr = preparedTx.toXDR();
+
+  const freighter = (window as any).freighter;
+  if (!freighter) throw new Error('WalletNotInstalledError');
+
+  const { signedTxXdr } = await freighter.signTransaction(txXdr, {
+    networkPassphrase: NETWORK_PASSPHRASE,
+  });
+
+  const submitRes = await server.sendTransaction(
+    TransactionBuilder.fromXDR(signedTxXdr, NETWORK_PASSPHRASE),
+  );
+
+  if (submitRes.status === 'ERROR') {
+    throw new Error(`TxSubmissionError: ${submitRes.errorResult?.toXDR()}`);
+  }
+
+  let getRes = await server.getTransaction(submitRes.hash);
+  for (let i = 0; i < 20 && getRes.status === 'NOT_FOUND'; i++) {
+    await new Promise((r) => setTimeout(r, 1500));
+    getRes = await server.getTransaction(submitRes.hash);
+  }
+
+  if (getRes.status !== 'SUCCESS') {
+    throw new Error(`TxSubmissionError: transaction ${getRes.status}`);
+  }
+
+  return submitRes.hash;
+}
 
 /**
  * Connects to the Freighter browser extension.
@@ -19,88 +91,105 @@ import type { BetSide, TxStatus } from '../types';
  * Throws WalletConnectionError if user rejects the request.
  */
 export async function connectWallet(): Promise<string> {
-  // TODO: implement
+  if (typeof window === 'undefined') throw new Error('Browser only');
+  const freighter = (window as any).freighter;
+  const albedo = (window as any).albedo;
+  if (freighter) {
+    await freighter.requestAccess();
+    const { publicKey } = await freighter.getPublicKey();
+    localStorage.setItem(LS_KEY, publicKey);
+    return publicKey;
+  }
+  if (albedo) {
+    const { pubkey } = await albedo.publicKey({ token: 'boxmeout' });
+    localStorage.setItem(LS_KEY, pubkey);
+    return pubkey;
+  }
+  throw new Error('WalletNotInstalledError: Install Freighter or Albedo');
 }
 
-/**
- * Disconnects the wallet and removes the stored address from localStorage.
- */
 export function disconnectWallet(): void {
-  // TODO: implement
+  localStorage.removeItem(LS_KEY);
 }
 
-/**
- * Returns the currently connected Stellar address from localStorage.
- * Returns null if no wallet is connected.
- */
 export function getConnectedAddress(): string | null {
-  // TODO: implement
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(LS_KEY);
 }
 
-/**
- * Builds and submits a place_bet contract invocation.
- *
- * Steps:
- *   1. Build XDR for InvokeContractHostFunction(market_contract, "place_bet", args)
- *   2. Pass XDR to Freighter for signing (freighter.signTransaction)
- *   3. Submit signed XDR to Stellar network via backend proxy or Horizon
- *   4. Poll for confirmation; return tx hash on SUCCESS
- *
- * Throws WalletSignError if user rejects signing.
- * Throws TxSubmissionError if network rejects the transaction.
- */
 export async function submitBet(
   market_contract_address: string,
   side: BetSide,
   amount_xlm: number,
 ): Promise<string> {
-  // TODO: implement
+  return buildAndSubmit(market_contract_address, 'place_bet', [
+    nativeToScVal(side, { type: 'symbol' }),
+    nativeToScVal(xlmToStroops(amount_xlm), { type: 'i128' }),
+  ]);
 }
 
-/**
- * Builds and submits a claim_winnings contract invocation for the connected wallet.
- * Returns the transaction hash on confirmation.
- */
-export async function submitClaim(
-  market_contract_address: string,
-): Promise<string> {
-  // TODO: implement
+export async function submitClaim(market_contract_address: string): Promise<string> {
+  return buildAndSubmit(market_contract_address, 'claim_winnings', []);
 }
 
-/**
- * Builds and submits a claim_refund contract invocation (cancelled market).
- * Returns the transaction hash on confirmation.
- */
-export async function submitRefund(
-  market_contract_address: string,
-): Promise<string> {
-  // TODO: implement
+export async function submitRefund(market_contract_address: string): Promise<string> {
+  return buildAndSubmit(market_contract_address, 'claim_refund', []);
 }
 
-/**
- * Returns the XLM balance of the connected wallet address.
- * Calls Horizon /accounts/:address and reads native balance.
- * Returns 0 if address is unfunded.
- */
+export interface CreateMarketParams {
+  matchId: string;
+  fighterA: string;
+  fighterB: string;
+  weightClass: string;
+  venue: string;
+  titleFight: boolean;
+  scheduledAt: string;
+  minBetXlm: number;
+  maxBetXlm: number;
+  feeBps: number;
+  lockBeforeMinutes: number;
+}
+
+export async function createMarket(params: CreateMarketParams): Promise<string> {
+  const factoryAddress = process.env.NEXT_PUBLIC_MARKET_FACTORY_ADDRESS;
+  if (!factoryAddress) throw new Error('NEXT_PUBLIC_MARKET_FACTORY_ADDRESS not set');
+  return buildAndSubmit(factoryAddress, 'create_market', [
+    nativeToScVal(params.matchId, { type: 'string' }),
+    nativeToScVal(params.fighterA, { type: 'string' }),
+    nativeToScVal(params.fighterB, { type: 'string' }),
+    nativeToScVal(params.weightClass, { type: 'string' }),
+    nativeToScVal(params.venue, { type: 'string' }),
+    nativeToScVal(params.titleFight, { type: 'bool' }),
+    nativeToScVal(BigInt(new Date(params.scheduledAt).getTime()), { type: 'u64' }),
+    nativeToScVal(xlmToStroops(params.minBetXlm), { type: 'i128' }),
+    nativeToScVal(xlmToStroops(params.maxBetXlm), { type: 'i128' }),
+    nativeToScVal(params.feeBps, { type: 'u32' }),
+    nativeToScVal(params.lockBeforeMinutes, { type: 'u32' }),
+  ]);
+}
+
 export async function getWalletBalance(): Promise<number> {
-  // TODO: implement
+  const address = getConnectedAddress();
+  if (!address) return 0;
+  try {
+    const res = await fetch(`${HORIZON_URL}/accounts/${address}`);
+    if (!res.ok) return 0;
+    const data = await res.json();
+    const native = (data.balances as any[]).find((b: any) => b.asset_type === 'native');
+    return native ? parseFloat(native.balance) : 0;
+  } catch {
+    return 0;
+  }
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-/**
- * Converts XLM (decimal) to stroops (integer i128 compatible).
- * 1 XLM = 10_000_000 stroops.
- * Uses integer arithmetic to avoid floating point errors.
- */
 export function xlmToStroops(xlm: number): bigint {
-  // TODO: implement
+  const [whole, frac = ''] = xlm.toString().split('.');
+  const fracPadded = frac.slice(0, 7).padEnd(7, '0');
+  return BigInt(whole) * 10_000_000n + BigInt(fracPadded);
 }
 
-/**
- * Converts stroops (bigint) to XLM (decimal number).
- * Used for display purposes only.
- */
 export function stroopsToXlm(stroops: bigint | string): number {
-  // TODO: implement
+  return Number(BigInt(stroops)) / 10_000_000;
 }

--- a/frontend/src/services/wallet.ts
+++ b/frontend/src/services/wallet.ts
@@ -1,70 +1,135 @@
 // ============================================================
 // BOXMEOUT — Wallet Service
 // Manages Freighter wallet connection and Stellar transactions.
-// Contributors: implement every function marked TODO.
 // ============================================================
 
-import type { BetSide, TxStatus } from '../types';
+import {
+  Contract,
+  Networks,
+  SorobanRpc,
+  TransactionBuilder,
+  BASE_FEE,
+  nativeToScVal,
+  xdr,
+} from '@stellar/stellar-sdk';
+import type { BetSide } from '../types';
 
-/**
- * Connects to the Freighter browser extension.
- * Falls back to Albedo if Freighter is not installed.
- *
- * Steps:
- *   1. Detect which wallet is available (window.freighter or window.albedo)
- *   2. Request user permission for the app
- *   3. Return the user's public Stellar G... address
- *
- * Throws WalletNotInstalledError if neither wallet is available.
- * Throws WalletConnectionError if user rejects the request.
- */
+const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet';
+const HORIZON_URL =
+  process.env.NEXT_PUBLIC_HORIZON_URL ?? 'https://horizon-testnet.stellar.org';
+const SOROBAN_RPC_URL =
+  NETWORK === 'mainnet'
+    ? 'https://soroban-rpc.stellar.org'
+    : 'https://soroban-testnet.stellar.org';
+const NETWORK_PASSPHRASE =
+  NETWORK === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
+
+const LS_KEY = 'boxmeout_wallet_address';
+
+// ─── Wallet connection ────────────────────────────────────────────────────────
+
 export async function connectWallet(): Promise<string> {
-  // TODO: implement
+  if (typeof window === 'undefined') throw new Error('Browser only');
+
+  const freighter = (window as any).freighter;
+  const albedo = (window as any).albedo;
+
+  if (freighter) {
+    await freighter.requestAccess();
+    const { publicKey } = await freighter.getPublicKey();
+    localStorage.setItem(LS_KEY, publicKey);
+    return publicKey;
+  }
+
+  if (albedo) {
+    const { pubkey } = await albedo.publicKey({ token: 'boxmeout' });
+    localStorage.setItem(LS_KEY, pubkey);
+    return pubkey;
+  }
+
+  throw new Error('WalletNotInstalledError: Install Freighter or Albedo');
 }
 
-/**
- * Disconnects the wallet and removes the stored address from localStorage.
- */
 export function disconnectWallet(): void {
-  // TODO: implement
+  localStorage.removeItem(LS_KEY);
 }
 
-/**
- * Returns the currently connected Stellar address from localStorage.
- * Returns null if no wallet is connected.
- */
 export function getConnectedAddress(): string | null {
-  // TODO: implement
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem(LS_KEY);
 }
 
-/**
- * Builds and submits a place_bet contract invocation.
- *
- * Steps:
- *   1. Build XDR for InvokeContractHostFunction(market_contract, "place_bet", args)
- *   2. Pass XDR to Freighter for signing (freighter.signTransaction)
- *   3. Submit signed XDR to Stellar network via backend proxy or Horizon
- *   4. Poll for confirmation; return tx hash on SUCCESS
- *
- * Throws WalletSignError if user rejects signing.
- * Throws TxSubmissionError if network rejects the transaction.
- */
+// ─── Transaction helpers ──────────────────────────────────────────────────────
+
+async function buildAndSubmit(
+  contractAddress: string,
+  method: string,
+  args: xdr.ScVal[],
+): Promise<string> {
+  const address = getConnectedAddress();
+  if (!address) throw new Error('WalletNotConnected');
+
+  const server = new SorobanRpc.Server(SOROBAN_RPC_URL);
+  const account = await server.getAccount(address);
+
+  const contract = new Contract(contractAddress);
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: NETWORK_PASSPHRASE,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const preparedTx = await server.prepareTransaction(tx);
+  const txXdr = preparedTx.toXDR();
+
+  const freighter = (window as any).freighter;
+  if (!freighter) throw new Error('WalletNotInstalledError');
+
+  const { signedTxXdr } = await freighter.signTransaction(txXdr, {
+    networkPassphrase: NETWORK_PASSPHRASE,
+  });
+
+  const submitRes = await server.sendTransaction(
+    TransactionBuilder.fromXDR(signedTxXdr, NETWORK_PASSPHRASE),
+  );
+
+  if (submitRes.status === 'ERROR') {
+    throw new Error(`TxSubmissionError: ${submitRes.errorResult?.toXDR()}`);
+  }
+
+  // Poll for confirmation
+  let getRes = await server.getTransaction(submitRes.hash);
+  for (let i = 0; i < 20 && getRes.status === 'NOT_FOUND'; i++) {
+    await new Promise((r) => setTimeout(r, 1500));
+    getRes = await server.getTransaction(submitRes.hash);
+  }
+
+  if (getRes.status !== 'SUCCESS') {
+    throw new Error(`TxSubmissionError: transaction ${getRes.status}`);
+  }
+
+  return submitRes.hash;
+}
+
+// ─── Public contract invocations ─────────────────────────────────────────────
+
 export async function submitBet(
   market_contract_address: string,
   side: BetSide,
   amount_xlm: number,
 ): Promise<string> {
-  // TODO: implement
+  return buildAndSubmit(market_contract_address, 'place_bet', [
+    nativeToScVal(side, { type: 'symbol' }),
+    nativeToScVal(xlmToStroops(amount_xlm), { type: 'i128' }),
+  ]);
 }
 
-/**
- * Builds and submits a claim_winnings contract invocation for the connected wallet.
- * Returns the transaction hash on confirmation.
- */
 export async function submitClaim(
   market_contract_address: string,
 ): Promise<string> {
-  // TODO: implement
+  return buildAndSubmit(market_contract_address, 'claim_winnings', []);
 }
 
 /**
@@ -74,33 +139,36 @@ export async function submitClaim(
 export async function submitRefund(
   market_contract_address: string,
 ): Promise<string> {
-  // TODO: implement
+  return buildAndSubmit(market_contract_address, 'claim_refund', []);
 }
 
-/**
- * Returns the XLM balance of the connected wallet address.
- * Calls Horizon /accounts/:address and reads native balance.
- * Returns 0 if address is unfunded.
- */
+// ─── Balance ──────────────────────────────────────────────────────────────────
+
 export async function getWalletBalance(): Promise<number> {
-  // TODO: implement
+  const address = getConnectedAddress();
+  if (!address) return 0;
+
+  try {
+    const res = await fetch(`${HORIZON_URL}/accounts/${address}`);
+    if (!res.ok) return 0;
+    const data = await res.json();
+    const native = (data.balances as any[]).find(
+      (b: any) => b.asset_type === 'native',
+    );
+    return native ? parseFloat(native.balance) : 0;
+  } catch {
+    return 0;
+  }
 }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
+// ─── Unit helpers ─────────────────────────────────────────────────────────────
 
-/**
- * Converts XLM (decimal) to stroops (integer i128 compatible).
- * 1 XLM = 10_000_000 stroops.
- * Uses integer arithmetic to avoid floating point errors.
- */
 export function xlmToStroops(xlm: number): bigint {
-  // TODO: implement
+  const [whole, frac = ''] = xlm.toString().split('.');
+  const fracPadded = frac.slice(0, 7).padEnd(7, '0');
+  return BigInt(whole) * 10_000_000n + BigInt(fracPadded);
 }
 
-/**
- * Converts stroops (bigint) to XLM (decimal number).
- * Used for display purposes only.
- */
 export function stroopsToXlm(stroops: bigint | string): number {
-  // TODO: implement
+  return Number(BigInt(stroops)) / 10_000_000;
 }


### PR DESCRIPTION
Changes                                                                                                       
  
closes #590                                                                                                               
  `frontend/src/services/wallet.ts`                                                                             
                                                                                                                
  - Implemented submitRefund() — builds XDR for claim_refund on the market contract, signs via Freighter,       
  submits to Soroban RPC, polls until SUCCESS, returns tx hash. Throws clearly on wallet or network failure.    
  - Added createMarket() — invokes create_market on the MarketFactory contract with all market params (fighters,
  weight class, venue, title fight, scheduled timestamp, min/max bet in stroops, fee bps, lock window).         
  - Added shared buildAndSubmit() helper used by all contract invocations (bet, claim, refund, create market) — 
  handles XDR build → Freighter sign → submit → poll.                                                           
  - Implemented remaining stubs: connectWallet() (Freighter with Albedo fallback), disconnectWallet(),          
  getConnectedAddress(), submitBet(), submitClaim(), getWalletBalance(), xlmToStroops(), stroopsToXlm().        
  
closes #591                                                                                                               
  `frontend/src/app/create/page.tsx`                                                                            
                                                                                                                
  - Implemented CreateMarketPage — admin-only form for creating boxing markets.                                 
  - Fields: Match ID, Fighter A, Fighter B, Weight Class (select with all 15 divisions), Venue, Title Fight     
  (checkbox), Scheduled At (datetime-local), Min Bet (XLM), Max Bet (XLM), Fee % (0–10), Lock Before (minutes). 
  - Validation: all required fields checked; min/max bet range enforced; fee clamped to 0–10 before submission. 
  - Submit flow: XLM values converted to stroops → createMarket() called → TxStatusToast shown → redirects to   
  /markets/[matchId] on success.                                                                                
  - Access guard: wallet not connected → connect prompt; connected address not in NEXT_PUBLIC_ADMIN_ADDRESSES → 
  "Access Denied" screen. 