### PR TITLE
feat(frontend): implement useMarket hook with live odds polling

### DIFF
--- a/frontend/src/hooks/useMarket.ts
+++ b/frontend/src/hooks/useMarket.ts
@@ -4,6 +4,7 @@
 
 import { useState, useEffect } from 'react';
 import type { Market } from '../types';
+import { fetchMarketById } from '../services/api';
 
 export interface UseMarketResult {
   market: Market | null;
@@ -17,6 +18,50 @@ export interface UseMarketResult {
  * Stops polling when status moves to locked/resolved/cancelled.
  */
 export function useMarket(market_id: string): UseMarketResult {
-  // TODO: implement
-  // Hint: polling interval should be conditional on market.status === "open"
+  const [market, setMarket] = useState<Market | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const data = await fetchMarketById(market_id);
+        if (cancelled) return;
+        setMarket(data);
+        setError(null);
+
+        if (data.status === 'open' && !intervalId) {
+          intervalId = setInterval(async () => {
+            try {
+              const updated = await fetchMarketById(market_id);
+              if (cancelled) return;
+              setMarket(updated);
+              if (updated.status !== 'open') {
+                clearInterval(intervalId!);
+                intervalId = null;
+              }
+            } catch (e) {
+              if (!cancelled) setError(e as Error);
+            }
+          }, 10_000);
+        }
+      } catch (e) {
+        if (!cancelled) setError(e as Error);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+      if (intervalId) clearInterval(intervalId);
+    };
+  }, [market_id]);
+
+  return { market, isLoading, error };
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -49,7 +49,14 @@ export async function fetchMarkets(
  * Throws NotFoundError on 404.
  */
 export async function fetchMarketById(market_id: string): Promise<Market> {
-  // TODO: implement
+  const res = await fetch(`${API_BASE}/api/markets/${market_id}`);
+  if (res.status === 404) {
+    const err = new Error(`Market ${market_id} not found`);
+    err.name = 'NotFoundError';
+    throw err;
+  }
+  if (!res.ok) throw new Error(`Failed to fetch market: ${res.status}`);
+  return res.json();
 }
 
 /**


### PR DESCRIPTION
closes #578 




- Implement useMarket(market_id) hook in frontend/src/hooks/useMarket.ts
  - Fetches market on mount via fetchMarketById(market_id)
  - Starts a 10-second polling interval when market.status === 'open' to keep odds live without manual refresh
  - Automatically clears the interval when status transitions to locked / resolved / cancelled / disputed
  - Uses a cancelled flag to prevent setState calls after unmount
  - Any fetch error (including 404 NotFoundError) is captured in the error state — hook never throws, so the consuming page won't crash
  - Returns { market, isLoading, error } matching UseMarketResult

- Implement fetchMarketById(market_id) in frontend/src/services/api.ts
  - GET /api/markets/:market_id
  - Throws a named NotFoundError on 404 for caller-side distinction
  - Throws a generic Error with HTTP status for other non-ok responses

Closes: useMarket hook task

## Closes

Closes #

## What this PR does

<!-- One paragraph. What did you implement? Do not explain how — the code does that. -->

## Testing

<!-- How did you verify this works? What test cases did you add? -->

## Screenshots (frontend changes only)

<!-- Add before/after screenshots or a short screen recording. -->

## Checklist

- [ ] I have read `docs/contributing.md`
- [ ] My code follows the naming conventions in the guidelines
- [ ] I have added or updated tests for my changes
- [ ] All tests pass locally (`cargo test` / `npm test`)
- [ ] Lint passes (`cargo clippy` / `npm run lint`)
- [ ] No `console.log` or `unwrap()` left in production paths
- [ ] No secrets committed
