### PR TITLE
feat: implement marketOddsBar component

### DIFF
--- a/frontend/src/components/market/MarketOddsBar.tsx
+++ b/frontend/src/components/market/MarketOddsBar.tsx
@@ -1,25 +1,17 @@
-// ============================================================
-// BOXMEOUT — MarketOddsBar Component
-// ============================================================
-
 interface MarketOddsBarProps {
-  pool_a: string;    // Stroops as string
+  pool_a: string;
   pool_b: string;
   pool_draw: string;
   fighter_a: string;
   fighter_b: string;
 }
 
-/**
- * Three-segment horizontal bar showing the proportional split of the pools.
- *
- * Layout: [== Fighter A ==][= Draw =][=== Fighter B ===]
- *
- * Width of each segment = pool_x / total_pool * 100%.
- * If total_pool is 0, render equal thirds.
- * Animate width changes with a CSS transition.
- * Show percentage label inside each segment (if wide enough, else hide).
- */
+const EQUAL = 100n / 3n; // 33n
+
+function pct(pool: bigint, total: bigint): bigint {
+  return total === 0n ? EQUAL : (pool * 100n) / total;
+}
+
 export function MarketOddsBar({
   pool_a,
   pool_b,
@@ -27,6 +19,37 @@ export function MarketOddsBar({
   fighter_a,
   fighter_b,
 }: MarketOddsBarProps): JSX.Element {
-  // TODO: implement
-  // Hint: convert pool strings to BigInt for safe math
+  const a = BigInt(pool_a);
+  const b = BigInt(pool_b);
+  const d = BigInt(pool_draw);
+  const total = a + b + d;
+
+  const pA = pct(a, total);
+  const pD = pct(d, total);
+  // Assign remainder to B to ensure segments always sum to 100
+  const pB = 100n - pA - pD;
+
+  const segments = [
+    { label: fighter_a, pct: pA, color: 'bg-blue-600' },
+    { label: 'Draw',    pct: pD, color: 'bg-yellow-500' },
+    { label: fighter_b, pct: pB, color: 'bg-red-600' },
+  ];
+
+  return (
+    <div className="flex w-full h-8 rounded overflow-hidden">
+      {segments.map(({ label, pct: p, color }) => (
+        <div
+          key={label}
+          className={`${color} flex items-center justify-center overflow-hidden transition-[width] duration-[400ms] ease-in-out`}
+          style={{ width: `${p}%` }}
+        >
+          {p >= 10n && (
+            <span className="text-white text-xs font-semibold truncate px-1">
+              {label} {p.toString()}%
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
 }


### PR DESCRIPTION
## What was implemented

  - BigInt throughout — pool_a/b/draw strings are converted with BigInt(), all math stays integer, no floats.                                                   
  - Zero-pool guard — total === 0n returns 33n (equal thirds) before any division.                                                                              
  - Remainder assigned to B — pB = 100n - pA - pD absorbs any rounding remainder so segments always sum to exactly 100%.                                        
  - Label visibility — hidden when p < 10n (BigInt comparison, matching the ≥10% rule).                                                                         
  - Animation — transition-[width] duration-[400ms] ease-in-out via Tailwind arbitrary value (maps to transition: width 0.4s ease).   

closes #573 