### PR TITLE
feat: implement countdown timer

### DIFF
--- a/frontend/src/components/ui/CountdownTimer.tsx
+++ b/frontend/src/components/ui/CountdownTimer.tsx
@@ -2,6 +2,8 @@
 // BOXMEOUT — CountdownTimer Component
 // ============================================================
 
+import { useMarketCountdown } from '@/hooks/useMarketCountdown';
+
 interface CountdownTimerProps {
   /** ISO 8601 timestamp of fight start */
   scheduled_at: string;
@@ -20,7 +22,25 @@ interface CountdownTimerProps {
  */
 export function CountdownTimer({
   scheduled_at,
-  label,
+  label = 'Starts in',
 }: CountdownTimerProps): JSX.Element {
-  // TODO: implement
+  const state = useMarketCountdown(scheduled_at);
+
+  if (state === 'LIVE') {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-red-600 px-2.5 py-0.5 text-xs font-semibold text-white animate-pulse">
+        LIVE
+      </span>
+    );
+  }
+
+  if (state === 'ENDED') {
+    return <span className="text-sm text-gray-400">ENDED</span>;
+  }
+
+  return (
+    <span className="text-sm text-gray-200">
+      {label} {state}
+    </span>
+  );
 }


### PR DESCRIPTION
## What was implemented

  - Delegates all timer logic (interval, cleanup, state computation) to useMarketCountdown — no duplicate timer code                                            
  - Renders a pulsing red badge for LIVE, gray text for ENDED, and "{label} {countdown}" otherwise                                                              
  - label defaults to "Starts in" so existing callers that omit it still get the expected "Starts in 2h 14m 32s" output     
closes #575 