### PR TITLE
feat: implement usePortfolio

### DIFF
--- a/frontend/src/hooks/usePortfolio.ts
+++ b/frontend/src/hooks/usePortfolio.ts
@@ -4,6 +4,9 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import type { Portfolio, TxStatus } from '../types';
+import { useWallet } from './useWallet';
+import { fetchPortfolio } from '../services/api';
+import { submitClaim, submitRefund } from '../services/wallet';
 
 export interface UsePortfolioResult {
   portfolio: Portfolio | null;
@@ -22,6 +25,53 @@ export interface UsePortfolioResult {
  * Refreshes automatically after a successful claim.
  */
 export function usePortfolio(): UsePortfolioResult {
-  // TODO: implement
-  // Hint: use useWallet() to get the connected address
+  const { address } = useWallet();
+  const [portfolio, setPortfolio] = useState<Portfolio | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [claimTxStatus, setClaimTxStatus] = useState<TxStatus>({
+    hash: null,
+    status: 'idle',
+    error: null,
+  });
+
+  const load = useCallback(async () => {
+    if (!address) { setPortfolio(null); return; }
+    setIsLoading(true);
+    setError(null);
+    try {
+      setPortfolio(await fetchPortfolio(address));
+    } catch (e: any) {
+      setError(e instanceof Error ? e : new Error(String(e)));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [address]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const runClaim = useCallback(async (fn: () => Promise<string>) => {
+    setClaimTxStatus({ hash: null, status: 'pending', error: null });
+    try {
+      const hash = await fn();
+      setClaimTxStatus({ hash, status: 'success', error: null });
+      await load();
+    } catch (e: any) {
+      setClaimTxStatus({ hash: null, status: 'error', error: e?.message ?? String(e) });
+    }
+  }, [load]);
+
+  const claimWinnings = useCallback(
+    (market_contract_address: string) =>
+      runClaim(() => submitClaim(market_contract_address)),
+    [runClaim],
+  );
+
+  const claimRefund = useCallback(
+    (market_contract_address: string) =>
+      runClaim(() => submitRefund(market_contract_address)),
+    [runClaim],
+  );
+
+  return { portfolio, isLoading, error, claimTxStatus, claimWinnings, claimRefund };
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -65,7 +65,9 @@ export async function fetchBetsByMarket(market_id: string): Promise<Bet[]> {
  * Returns the full Portfolio object.
  */
 export async function fetchPortfolio(address: string): Promise<Portfolio> {
-  // TODO: implement
+  const res = await fetch(`${API_BASE}/api/portfolio/${address}`);
+  if (!res.ok) throw new Error(`fetchPortfolio failed: ${res.status}`);
+  return res.json();
 }
 
 /**


### PR DESCRIPTION
## Here's what was implemented:                                                                                                                            
                                                                                                                                                                
  - load — fetches portfolio when address changes; sets null when disconnected                                                                                  
  - runClaim — shared helper that sets pending → calls the wallet fn → sets success + refetches, or sets error                                                  
  - claimWinnings / claimRefund — thin wrappers over runClaim calling submitClaim / submitRefund                                                                
  - Also implemented fetchPortfolio in api.ts which was a required TODO stub     

closes #586 