### PR TITLE
feat: implement submitclaim() in wallet.ts

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -7,6 +7,8 @@ NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
 
 # ── Contract Addresses ────────────────────────────────────────
 NEXT_PUBLIC_MARKET_FACTORY_ADDRESS=
+# Native XLM token contract (testnet: CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC)
+NEXT_PUBLIC_XLM_TOKEN_ADDRESS=CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC
 
 # ── Admin Wallet Addresses (comma-separated G... addresses) ───
 NEXT_PUBLIC_ADMIN_ADDRESSES=

--- a/frontend/src/services/wallet.ts
+++ b/frontend/src/services/wallet.ts
@@ -10,6 +10,7 @@ import {
   TransactionBuilder,
   BASE_FEE,
   nativeToScVal,
+  Address,
   xdr,
 } from '@stellar/stellar-sdk';
 import type { BetSide } from '../types';
@@ -123,11 +124,25 @@ export async function submitBet(
 }
 
 export async function submitClaim(market_contract_address: string): Promise<string> {
-  return buildAndSubmit(market_contract_address, 'claim_winnings', []);
+  const bettor = getConnectedAddress();
+  if (!bettor) throw new Error('WalletNotConnected');
+  const token = process.env.NEXT_PUBLIC_XLM_TOKEN_ADDRESS;
+  if (!token) throw new Error('NEXT_PUBLIC_XLM_TOKEN_ADDRESS not set');
+  return buildAndSubmit(market_contract_address, 'claim_winnings', [
+    new Address(bettor).toScVal(),
+    new Address(token).toScVal(),
+  ]);
 }
 
 export async function submitRefund(market_contract_address: string): Promise<string> {
-  return buildAndSubmit(market_contract_address, 'claim_refund', []);
+  const bettor = getConnectedAddress();
+  if (!bettor) throw new Error('WalletNotConnected');
+  const token = process.env.NEXT_PUBLIC_XLM_TOKEN_ADDRESS;
+  if (!token) throw new Error('NEXT_PUBLIC_XLM_TOKEN_ADDRESS not set');
+  return buildAndSubmit(market_contract_address, 'claim_refund', [
+    new Address(bettor).toScVal(),
+    new Address(token).toScVal(),
+  ]);
 }
 
 export interface CreateMarketParams {


### PR DESCRIPTION
## What is implemented

Both submitClaim and submitRefund now correctly pass the two args the contract requires (bettor and token), and throw explicitly on  
  wallet-not-connected or missing env var. All other failure paths (network error, tx rejection, non-SUCCESS status) propagate through buildAndSubmit unchanged.

closes #589 