### PR TITLE
feat: implement fetchPortfolio in api.ts

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -81,7 +81,14 @@ export async function fetchBetsByMarket(market_id: string): Promise<Bet[]> {
  * Returns the full Portfolio object.
  */
 export async function fetchPortfolio(address: string): Promise<Portfolio> {
-  // TODO: implement
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}/api/portfolio/${address}`);
+  } catch (e) {
+    throw new NetworkError(`Failed to fetch portfolio for ${address}: ${(e as Error).message}`);
+  }
+  if (!res.ok) throw new NetworkError(`Failed to fetch portfolio for ${address}: ${res.status} ${res.statusText}`);
+  return res.json() as Promise<Portfolio>;
 }
 
 /**


### PR DESCRIPTION
##  What was implemented

- Wraps the fetch call in a try/catch to handle network-level failures (DNS, timeout, etc.) with an informative message including the address                 
  - Throws NetworkError on any non-200 response, including the status code and status text                                                                      
  - Returns the parsed JSON typed as Portfolio                                                                                                                  
  
closes #588 