### PR TITLE
feat: implement error boundary

### DIFF
--- a/frontend/src/app/markets/[market_id]/page.tsx
+++ b/frontend/src/app/markets/[market_id]/page.tsx
@@ -2,6 +2,8 @@
 // BOXMEOUT — Market Detail Page (/markets/[market_id])
 // ============================================================
 
+import { ErrorBoundary } from '../../../components/ui/ErrorBoundary';
+
 interface MarketDetailPageProps {
   params: { market_id: string };
 }
@@ -23,8 +25,16 @@ interface MarketDetailPageProps {
  * Shows 404 message if market not found.
  * Shows error boundary fallback on unexpected errors.
  */
+function MarketDetailContent({ market_id }: { market_id: string }): JSX.Element {
+  // TODO: implement
+}
+
 export default function MarketDetailPage({
   params,
 }: MarketDetailPageProps): JSX.Element {
-  // TODO: implement
+  return (
+    <ErrorBoundary>
+      <MarketDetailContent market_id={params.market_id} />
+    </ErrorBoundary>
+  );
 }

--- a/frontend/src/components/ui/ErrorBoundary.tsx
+++ b/frontend/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,39 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('[ErrorBoundary]', error, info.componentStack);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return this.props.fallback ?? (
+        <div className="text-center mt-20 space-y-3">
+          <p className="text-gray-400">Something went wrong loading this market.</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="px-4 py-2 rounded-lg bg-amber-500 hover:bg-amber-400 font-semibold text-black text-sm"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## What was implemented
  - `ErrorBoundary.tsx` — class component with getDerivedStateFromError to set error state, componentDidCatch to console.error the error and component stack,   
  and a default fallback with the required message and reload button. Accepts an optional fallback prop for reuse elsewhere.                                    
  - `MarketDetailPage` — the TODO content is extracted into MarketDetailContent (so the boundary can actually catch its render errors), then wrapped with       
  <ErrorBoundary>.                                                                                                                                              
                                                                                                                                                                
  The content extraction into a child component is necessary because an error boundary can only catch errors in its children, not in itself — if the boundary   
  and the content were the same component, it couldn't catch its own errors.  
  
  closes #596 