### PR TITLE
feat: implement market detail page with recent bets and 404 handling

### DIFF
--- a/frontend/src/app/markets/[market_id]/MarketDetailContent.tsx
+++ b/frontend/src/app/markets/[market_id]/MarketDetailContent.tsx
@@ -1,31 +1,63 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { useMarket } from '../../../hooks/useMarket';
-import { useBet } from '../../../hooks/useBet';
 import { MarketOddsBar } from '../../../components/market/MarketOddsBar';
 import { MarketStatusBadge } from '../../../components/market/MarketStatusBadge';
 import { CountdownTimer } from '../../../components/ui/CountdownTimer';
 import { BetPanel } from '../../../components/bet/BetPanel';
 import { stellarExplorerUrl } from '../../../services/wallet';
+import { fetchBetsByMarket, NotFoundError } from '../../../services/api';
+import type { Bet } from '../../../types';
+
+const SIDE_LABEL: Record<string, string> = {
+  fighter_a: 'Fighter A',
+  fighter_b: 'Fighter B',
+  draw: 'Draw',
+};
+
+function truncate(addr: string) {
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+function fmtXlm(stroops: string) {
+  return (parseInt(stroops, 10) / 1e7).toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
 
 export default function MarketDetailContent({ market_id }: { market_id: string }): JSX.Element {
   const { market, isLoading, error } = useMarket(market_id);
+  const [recentBets, setRecentBets] = useState<Bet[]>([]);
+
+  useEffect(() => {
+    if (!market) return;
+    fetchBetsByMarket(market_id)
+      .then((bets) => setRecentBets(bets.slice(0, 20)))
+      .catch(() => {/* non-critical */});
+  }, [market_id, market]);
 
   if (isLoading) {
     return <main className="max-w-4xl mx-auto px-4 py-8 text-gray-400">Loading…</main>;
   }
 
-  if (error || !market) {
+  if (error instanceof NotFoundError || !market) {
     return (
       <main className="max-w-4xl mx-auto px-4 py-8 text-center">
+        <p className="text-2xl font-bold text-white mb-2">404</p>
         <p className="text-gray-400">Market not found.</p>
       </main>
     );
   }
 
-  const poolA = (parseInt(market.pool_a, 10) / 1e7).toFixed(2);
-  const poolB = (parseInt(market.pool_b, 10) / 1e7).toFixed(2);
-  const poolDraw = (parseInt(market.pool_draw, 10) / 1e7).toFixed(2);
+  if (error) {
+    return (
+      <main className="max-w-4xl mx-auto px-4 py-8 text-center">
+        <p className="text-gray-400">Failed to load market. Please try again.</p>
+      </main>
+    );
+  }
+
+  const sideLabel = (side: string) =>
+    side === 'fighter_a' ? market.fighter_a : side === 'fighter_b' ? market.fighter_b : 'Draw';
 
   return (
     <main className="max-w-4xl mx-auto px-4 py-6 space-y-6">
@@ -55,57 +87,93 @@ export default function MarketDetailContent({ market_id }: { market_id: string }
           fighter_b={market.fighter_b}
         />
         <div className="flex flex-wrap justify-between text-xs text-gray-400 gap-2">
-          <span>{poolA} XLM on {market.fighter_a}</span>
-          <span>{poolDraw} XLM Draw</span>
-          <span>{poolB} XLM on {market.fighter_b}</span>
+          <span>{fmtXlm(market.pool_a)} XLM on {market.fighter_a}</span>
+          <span>{fmtXlm(market.pool_draw)} XLM Draw</span>
+          <span>{fmtXlm(market.pool_b)} XLM on {market.fighter_b}</span>
         </div>
       </div>
 
-      {/* Two-column on desktop, stacked on mobile */}
+      {/* Two-column on desktop */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* BetPanel — full width mobile, right col desktop */}
+        {/* BetPanel — right col on desktop */}
         <div className="lg:col-start-3 lg:row-start-1">
           <BetPanel market={market} />
         </div>
 
-        {/* Recent bets — full width mobile, spans 2 cols desktop */}
+        {/* Recent bets — left 2 cols on desktop */}
         <div className="lg:col-span-2 lg:row-start-1 space-y-3">
           <h2 className="text-white font-semibold">Recent Bets</h2>
-          <p className="text-gray-500 text-sm">No recent bets yet.</p>
+          {recentBets.length === 0 ? (
+            <p className="text-gray-500 text-sm">No bets yet.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full text-sm text-left text-gray-300">
+                <thead>
+                  <tr className="text-xs text-gray-500 border-b border-gray-800">
+                    <th className="pb-2 pr-4">Bettor</th>
+                    <th className="pb-2 pr-4">Side</th>
+                    <th className="pb-2 pr-4">Amount</th>
+                    <th className="pb-2">Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {recentBets.map((bet) => (
+                    <tr key={bet.tx_hash} className="border-b border-gray-800/50">
+                      <td className="py-2 pr-4 font-mono text-xs">
+                        <a
+                          href={stellarExplorerUrl('tx', bet.tx_hash)}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-amber-400 hover:underline"
+                        >
+                          {truncate(bet.tx_hash)}
+                        </a>
+                      </td>
+                      <td className="py-2 pr-4 whitespace-nowrap">{sideLabel(bet.side)}</td>
+                      <td className="py-2 pr-4 whitespace-nowrap">{bet.amount_xlm} XLM</td>
+                      <td className="py-2 text-gray-500 whitespace-nowrap text-xs">
+                        {new Date(bet.placed_at).toLocaleTimeString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       </div>
 
-      {/* Oracle info — shown after resolved */}
+      {/* Oracle info — shown after resolution */}
       {market.status === 'resolved' && market.outcome && (
-        <div className="bg-gray-900 rounded-xl p-4 text-sm space-y-3">
-          <div>
-            <p className="text-gray-400">Outcome: <span className="text-white font-semibold capitalize">{market.outcome.replace('_', ' ')}</span></p>
-          </div>
+        <div className="bg-gray-900 rounded-xl p-4 text-sm space-y-2">
+          <p className="text-gray-400">
+            Outcome: <span className="text-white font-semibold capitalize">{market.outcome.replace('_', ' ')}</span>
+          </p>
           {market.oracle_address && (
-            <div>
-              <p className="text-gray-400">Oracle: </p>
+            <p className="text-gray-400">
+              Oracle:{' '}
               <a
                 href={stellarExplorerUrl('account', market.oracle_address)}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-amber-400 hover:text-amber-300 underline font-mono text-xs break-all"
+                className="text-amber-400 hover:underline font-mono text-xs break-all"
               >
-                {market.oracle_address.slice(0, 16)}…
+                {market.oracle_address}
               </a>
-            </div>
+            </p>
           )}
           {market.resolution_tx_hash && (
-            <div>
-              <p className="text-gray-400">Resolution TX: </p>
+            <p className="text-gray-400">
+              Resolution TX:{' '}
               <a
                 href={stellarExplorerUrl('tx', market.resolution_tx_hash)}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-amber-400 hover:text-amber-300 underline font-mono text-xs break-all"
+                className="text-amber-400 hover:underline font-mono text-xs break-all"
               >
-                {market.resolution_tx_hash.slice(0, 16)}…
+                {market.resolution_tx_hash}
               </a>
-            </div>
+            </p>
           )}
         </div>
       )}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -94,7 +94,14 @@ export async function fetchMarketById(market_id: string): Promise<Market> {
  * Returns all bets for the market.
  */
 export async function fetchBetsByMarket(market_id: string): Promise<Bet[]> {
-  // TODO: implement
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}/api/markets/${market_id}/bets`);
+  } catch (e) {
+    throw new NetworkError((e as Error).message);
+  }
+  if (!res.ok) throw new NetworkError(`Unexpected response: ${res.status}`);
+  return res.json();
 }
 
 /**


### PR DESCRIPTION
## Closes

Closes #579 

## What this PR does

<!-- One paragraph. What did you implement? Do not explain how — the code does that. -->

## Testing

<!-- How did you verify this works? What test cases did you add? -->

## Screenshots (frontend changes only)

<!-- Add before/after screenshots or a short screen recording. -->

## Checklist

- [ ] I have read `docs/contributing.md`
- [ ] My code follows the naming conventions in the guidelines
- [ ] I have added or updated tests for my changes
- [ ] All tests pass locally (`cargo test` / `npm test`)
- [ ] Lint passes (`cargo clippy` / `npm run lint`)
- [ ] No `console.log` or `unwrap()` left in production paths
- [ ] No secrets committed
