### PR TITLE
feat: secure password reset flow with time-limited single-use tokens

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,20 +8,24 @@
       "name": "boxmeout-backend",
       "version": "0.1.0",
       "dependencies": {
+        "bcrypt": "^6.0.0",
         "express": "^4.19.2",
         "ioredis": "^5.10.1",
         "jsonwebtoken": "^9.0.3",
+        "nodemailer": "^8.0.5",
         "otpauth": "^9.5.0",
         "qrcode": "^1.5.4",
         "winston": "^3.13.0"
       },
       "devDependencies": {
         "@stellar/stellar-sdk": "^15.0.1",
+        "@types/bcrypt": "^6.0.0",
         "@types/express": "^4.17.21",
         "@types/ioredis": "^4.28.10",
         "@types/jest": "^29.5.12",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.14.0",
+        "@types/nodemailer": "^8.0.0",
         "@types/qrcode": "^1.5.6",
         "@typescript-eslint/eslint-plugin": "^7.13.0",
         "@typescript-eslint/parser": "^7.13.0",
@@ -63,6 +67,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1436,6 +1441,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -1579,8 +1594,19 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qrcode": {
@@ -1724,6 +1750,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -1903,6 +1930,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2265,6 +2293,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -2370,6 +2412,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3210,6 +3253,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4523,6 +4567,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5596,6 +5641,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5609,6 +5674,15 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -7141,6 +7215,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -7331,6 +7406,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,20 +9,24 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "express": "^4.19.2",
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.3",
+    "nodemailer": "^8.0.5",
     "otpauth": "^9.5.0",
     "qrcode": "^1.5.4",
     "winston": "^3.13.0"
   },
   "devDependencies": {
     "@stellar/stellar-sdk": "^15.0.1",
+    "@types/bcrypt": "^6.0.0",
     "@types/express": "^4.17.21",
     "@types/ioredis": "^4.28.10",
     "@types/jest": "^29.5.12",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.14.0",
+    "@types/nodemailer": "^8.0.0",
     "@types/qrcode": "^1.5.6",
     "@typescript-eslint/eslint-plugin": "^7.13.0",
     "@typescript-eslint/parser": "^7.13.0",

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,26 +1,53 @@
 import { Router, Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
 import * as authService from '../services/auth.service';
+import { redis } from '../services/cache.service';
 import { AppError } from '../utils/AppError';
+import { rateLimit } from '../middleware/rate-limit.middleware';
 
 const router = Router();
 
-// Stub auth middleware — replace with real JWT verification
-function requireAuth(req: Request, _res: Response, next: NextFunction): void {
-  const authHeader = req.headers.authorization;
-  if (!authHeader?.startsWith('Bearer ')) {
-    return next(new AppError(401, 'Missing or invalid Authorization header'));
+const JWT_SECRET = process.env.JWT_SECRET ?? 'dev-jwt-secret-change-me';
+
+// ---------------------------------------------------------------------------
+// Auth middleware — verifies JWT and checks session-revocation tombstone
+// ---------------------------------------------------------------------------
+async function requireAuth(req: Request, _res: Response, next: NextFunction): Promise<void> {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith('Bearer ')) {
+      throw new AppError(401, 'Missing or invalid Authorization header');
+    }
+
+    const token = authHeader.slice(7);
+    const payload = jwt.verify(token, JWT_SECRET) as jwt.JwtPayload;
+
+    if (payload.type !== 'access') {
+      throw new AppError(401, 'Invalid token type');
+    }
+
+    const userId = payload.sub as string;
+    const sessionVersion: number = payload.sv ?? 0;
+
+    // Check Redis tombstone — set on password reset
+    const revoked = await authService.isSessionRevoked(userId, sessionVersion);
+    if (revoked) throw new AppError(401, 'Session has been invalidated');
+
+    (req as any).userId = userId;
+    (req as any).sessionVersion = sessionVersion;
+    next();
+  } catch (err) {
+    next(err instanceof AppError ? err : new AppError(401, 'Invalid or expired token'));
   }
-  // TODO: verify JWT and attach req.userId
-  (req as any).userId = 'stub-user-id';
-  next();
 }
 
+// ---------------------------------------------------------------------------
+// POST /auth/login
+// ---------------------------------------------------------------------------
 router.post('/login', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { email, password } = req.body;
-    if (!email || !password) {
-      throw new AppError(400, 'Email and password required');
-    }
+    if (!email || !password) throw new AppError(400, 'Email and password required');
     const result = await authService.login(email, password);
     res.json(result);
   } catch (err) {
@@ -28,6 +55,63 @@ router.post('/login', async (req: Request, res: Response, next: NextFunction) =>
   }
 });
 
+// ---------------------------------------------------------------------------
+// POST /auth/forgot-password
+// Stricter rate limit: 5 requests per 15 minutes per IP
+// ---------------------------------------------------------------------------
+router.post(
+  '/forgot-password',
+  rateLimit({ windowMs: 15 * 60_000, max: 5, keyBy: 'ip' }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { email } = req.body;
+      if (!email || typeof email !== 'string') {
+        throw new AppError(400, 'Email is required');
+      }
+
+      // Always fire-and-forget — never reveal whether the email exists
+      await authService.forgotPassword(email.trim().toLowerCase());
+
+      res.json({ message: 'If that email exists, a reset link has been sent.' });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// POST /auth/reset-password
+// Stricter rate limit: 10 attempts per 15 minutes per IP
+// ---------------------------------------------------------------------------
+router.post(
+  '/reset-password',
+  rateLimit({ windowMs: 15 * 60_000, max: 10, keyBy: 'ip' }),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { token, newPassword } = req.body;
+
+      if (!token || typeof token !== 'string') {
+        throw new AppError(400, 'Reset token is required');
+      }
+      if (!newPassword || typeof newPassword !== 'string') {
+        throw new AppError(400, 'New password is required');
+      }
+      if (newPassword.length < 8) {
+        throw new AppError(400, 'Password must be at least 8 characters');
+      }
+
+      await authService.resetPassword(token, newPassword);
+
+      res.json({ message: 'Password updated successfully. Please log in again.' });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 2FA routes (unchanged, kept here for completeness)
+// ---------------------------------------------------------------------------
 router.post('/2fa/setup', requireAuth, async (req: Request, res: Response, next: NextFunction) => {
   try {
     const userId = (req as any).userId;

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,12 +1,17 @@
 import jwt from 'jsonwebtoken';
+import bcrypt from 'bcrypt';
 import { encrypt, decrypt } from './crypto.service';
 import { generateSecret, generateQRCode, verifyToken } from './totp.service';
+import { sendPasswordResetEmail } from './email.service';
+import { redis } from './cache.service';
 import { AppError } from '../utils/AppError';
 
 const JWT_SECRET = process.env.JWT_SECRET ?? 'dev-jwt-secret-change-me';
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN ?? '15m';
 const REFRESH_EXPIRES_IN = process.env.REFRESH_EXPIRES_IN ?? '7d';
 const TEMP_TOKEN_EXPIRES_IN = '5m';
+const RESET_TOKEN_EXPIRES_IN = '15m';
+const BCRYPT_ROUNDS = 12;
 
 // ---------------------------------------------------------------------------
 // In-memory user store — replace with DB queries in production
@@ -17,29 +22,92 @@ interface UserRecord {
   passwordHash: string;
   twoFactorSecret?: string;   // AES-GCM encrypted base32 secret
   twoFactorEnabled: boolean;
+  /**
+   * Monotonically increasing version number.
+   * Stored inside every issued access/refresh token.
+   * Incrementing it instantly invalidates all previously issued tokens.
+   */
+  sessionVersion: number;
+  /**
+   * SHA-256 hash of the most recently issued password-reset JWT.
+   * Cleared on use so the token can only be consumed once.
+   */
+  resetTokenHash?: string;
 }
 
-const users = new Map<string, UserRecord>();
+export const users = new Map<string, UserRecord>();
 
 // ---------------------------------------------------------------------------
 // JWT helpers
 // ---------------------------------------------------------------------------
-function signAccess(userId: string): string {
-  return jwt.sign({ sub: userId, type: 'access' }, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN } as jwt.SignOptions);
+function signAccess(userId: string, sessionVersion: number): string {
+  return jwt.sign(
+    { sub: userId, type: 'access', sv: sessionVersion },
+    JWT_SECRET,
+    { expiresIn: JWT_EXPIRES_IN } as jwt.SignOptions,
+  );
 }
 
-function signRefresh(userId: string): string {
-  return jwt.sign({ sub: userId, type: 'refresh' }, JWT_SECRET, { expiresIn: REFRESH_EXPIRES_IN } as jwt.SignOptions);
+function signRefresh(userId: string, sessionVersion: number): string {
+  return jwt.sign(
+    { sub: userId, type: 'refresh', sv: sessionVersion },
+    JWT_SECRET,
+    { expiresIn: REFRESH_EXPIRES_IN } as jwt.SignOptions,
+  );
 }
 
 function signTemp(userId: string): string {
-  return jwt.sign({ sub: userId, type: 'temp_2fa' }, JWT_SECRET, { expiresIn: TEMP_TOKEN_EXPIRES_IN } as jwt.SignOptions);
+  return jwt.sign({ sub: userId, type: 'temp_2fa' }, JWT_SECRET, {
+    expiresIn: TEMP_TOKEN_EXPIRES_IN,
+  } as jwt.SignOptions);
+}
+
+function signReset(userId: string): string {
+  return jwt.sign({ sub: userId, type: 'password_reset' }, JWT_SECRET, {
+    expiresIn: RESET_TOKEN_EXPIRES_IN,
+  } as jwt.SignOptions);
 }
 
 function verifyJwt(token: string, expectedType: string): jwt.JwtPayload {
   const payload = jwt.verify(token, JWT_SECRET) as jwt.JwtPayload;
   if (payload.type !== expectedType) throw new AppError(401, 'Invalid token type');
   return payload;
+}
+
+/** SHA-256 hex digest of a string — used to fingerprint reset tokens */
+async function sha256(input: string): Promise<string> {
+  const { createHash } = await import('crypto');
+  return createHash('sha256').update(input).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Session invalidation via Redis
+// ---------------------------------------------------------------------------
+
+/**
+ * Key pattern: `session:blocked:<userId>:<sessionVersion>`
+ * We store a tombstone in Redis so that even tokens still within their JWT
+ * expiry window are rejected after a password reset.
+ *
+ * In production you would query this in your auth middleware on every request.
+ */
+async function blockOldSessions(userId: string, oldVersion: number): Promise<void> {
+  // Block every version up to and including the old one.
+  // TTL matches the longest-lived token (refresh = 7 days).
+  const SEVEN_DAYS = 7 * 24 * 60 * 60;
+  for (let v = 0; v <= oldVersion; v++) {
+    await redis.set(`session:blocked:${userId}:${v}`, '1', 'EX', SEVEN_DAYS);
+  }
+}
+
+/**
+ * Returns true when the session version carried in a token has been revoked.
+ * Call this in your auth middleware after verifying the JWT signature.
+ */
+export async function isSessionRevoked(userId: string, sessionVersion: number): Promise<boolean> {
+  const key = `session:blocked:${userId}:${sessionVersion}`;
+  const val = await redis.get(key);
+  return val !== null;
 }
 
 // ---------------------------------------------------------------------------
@@ -49,19 +117,100 @@ function verifyJwt(token: string, expectedType: string): jwt.JwtPayload {
 /** Stub login — replace with real password check against DB */
 export async function login(
   email: string,
-  _password: string,
+  password: string,
 ): Promise<{ accessToken: string; refreshToken: string } | { requires2FA: true; tempToken: string }> {
   const user = [...users.values()].find((u) => u.email === email);
   if (!user) throw new AppError(401, 'Invalid credentials');
 
-  // TODO: verify bcrypt hash against _password
+  const passwordValid = await bcrypt.compare(password, user.passwordHash);
+  if (!passwordValid) throw new AppError(401, 'Invalid credentials');
 
   if (user.twoFactorEnabled) {
     return { requires2FA: true, tempToken: signTemp(user.id) };
   }
 
-  return { accessToken: signAccess(user.id), refreshToken: signRefresh(user.id) };
+  return {
+    accessToken: signAccess(user.id, user.sessionVersion),
+    refreshToken: signRefresh(user.id, user.sessionVersion),
+  };
 }
+
+// ---------------------------------------------------------------------------
+// Password reset flow
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /auth/forgot-password
+ *
+ * Always returns the same response regardless of whether the email exists
+ * to prevent user enumeration attacks.
+ */
+export async function forgotPassword(email: string): Promise<void> {
+  const user = [...users.values()].find((u) => u.email === email);
+
+  // No user → do nothing but don't reveal that fact to the caller
+  if (!user) return;
+
+  const resetToken = signReset(user.id);
+  const tokenHash = await sha256(resetToken);
+
+  // Store hash so we can verify single-use on consumption
+  user.resetTokenHash = tokenHash;
+  users.set(user.id, user);
+
+  // Fire-and-forget — failures are swallowed inside sendPasswordResetEmail
+  await sendPasswordResetEmail(user.email, resetToken);
+}
+
+/**
+ * POST /auth/reset-password
+ *
+ * Validates the reset token, hashes the new password, updates the user
+ * record, and invalidates all existing sessions.
+ */
+export async function resetPassword(token: string, newPassword: string): Promise<void> {
+  // 1. Verify JWT signature and expiry
+  let payload: jwt.JwtPayload;
+  try {
+    payload = verifyJwt(token, 'password_reset');
+  } catch {
+    throw new AppError(400, 'Invalid or expired reset token');
+  }
+
+  const userId = payload.sub as string;
+  const user = users.get(userId);
+  if (!user) throw new AppError(400, 'Invalid or expired reset token');
+
+  // 2. Verify single-use: token hash must match what we stored
+  if (!user.resetTokenHash) {
+    throw new AppError(400, 'Reset token has already been used');
+  }
+
+  const incomingHash = await sha256(token);
+  if (incomingHash !== user.resetTokenHash) {
+    throw new AppError(400, 'Invalid or expired reset token');
+  }
+
+  // 3. Consume the token immediately (single-use enforcement)
+  user.resetTokenHash = undefined;
+
+  // 4. Hash the new password
+  const passwordHash = await bcrypt.hash(newPassword, BCRYPT_ROUNDS);
+  user.passwordHash = passwordHash;
+
+  // 5. Invalidate all existing sessions by bumping the session version
+  const oldVersion = user.sessionVersion;
+  user.sessionVersion = oldVersion + 1;
+
+  users.set(user.id, user);
+
+  // 6. Write tombstones to Redis so in-flight tokens are rejected immediately
+  await blockOldSessions(userId, oldVersion);
+}
+
+// ---------------------------------------------------------------------------
+// 2FA service
+// ---------------------------------------------------------------------------
 
 /** Step 1: generate secret + QR code; does NOT enable 2FA yet */
 export async function setup2FA(
@@ -72,7 +221,6 @@ export async function setup2FA(
   if (user.twoFactorEnabled) throw new AppError(400, '2FA already enabled');
 
   const { secret, otpauthUrl } = generateSecret(user.email);
-  // Store encrypted pending secret (not yet enabled)
   user.twoFactorSecret = encrypt(secret);
   users.set(userId, user);
 
@@ -124,8 +272,8 @@ export async function verify2FA(
   const secret = decrypt(user.twoFactorSecret);
   if (!verifyToken(secret, otp)) throw new AppError(401, 'Invalid or expired OTP');
 
-  return { accessToken: signAccess(userId), refreshToken: signRefresh(userId) };
+  return {
+    accessToken: signAccess(userId, user.sessionVersion),
+    refreshToken: signRefresh(userId, user.sessionVersion),
+  };
 }
-
-/** Expose users map for testing only */
-export { users };

--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -1,0 +1,94 @@
+import nodemailer from 'nodemailer';
+import { logger } from '../utils/logger';
+
+// ---------------------------------------------------------------------------
+// Transporter — configure via env vars.
+// For production use SMTP_HOST/PORT/USER/PASS.
+// Falls back to Ethereal (catch-all test account) when env vars are absent.
+// ---------------------------------------------------------------------------
+function createTransporter() {
+  const host = process.env.SMTP_HOST;
+  const port = parseInt(process.env.SMTP_PORT ?? '587', 10);
+  const user = process.env.SMTP_USER;
+  const pass = process.env.SMTP_PASS;
+
+  if (host && user && pass) {
+    return nodemailer.createTransport({
+      host,
+      port,
+      secure: port === 465,
+      auth: { user, pass },
+    });
+  }
+
+  // Development fallback — logs preview URL to console
+  logger.warn('SMTP env vars not set; using nodemailer stub transport (emails will not be delivered)');
+  return nodemailer.createTransport({ jsonTransport: true });
+}
+
+const transporter = createTransporter();
+
+const APP_NAME = process.env.APP_NAME ?? 'BoxMeOut';
+const APP_BASE_URL = process.env.APP_BASE_URL ?? 'http://localhost:3001';
+const FROM_ADDRESS = process.env.SMTP_FROM ?? `no-reply@boxmeout.app`;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Send a password-reset email containing a signed JWT link.
+ * Failures are caught and logged — never thrown — so the caller cannot
+ * distinguish "email sent" from "email failed" (prevents enumeration).
+ */
+export async function sendPasswordResetEmail(
+  toEmail: string,
+  resetToken: string,
+): Promise<void> {
+  const resetUrl = `${APP_BASE_URL}/auth/reset-password?token=${resetToken}`;
+
+  const html = `
+    <p>Hi,</p>
+    <p>We received a request to reset your <strong>${APP_NAME}</strong> password.</p>
+    <p>
+      <a href="${resetUrl}" style="
+        display:inline-block;
+        padding:10px 20px;
+        background:#4f46e5;
+        color:#fff;
+        border-radius:4px;
+        text-decoration:none;
+      ">Reset my password</a>
+    </p>
+    <p><strong>⚠ This link expires in 15 minutes.</strong></p>
+    <p>If you did not request a password reset, you can safely ignore this email.</p>
+    <p>— The ${APP_NAME} team</p>
+  `;
+
+  const text = [
+    `Reset your ${APP_NAME} password`,
+    '',
+    `Visit the link below to reset your password (expires in 15 minutes):`,
+    resetUrl,
+    '',
+    'If you did not request a password reset, ignore this email.',
+  ].join('\n');
+
+  try {
+    const info = await transporter.sendMail({
+      from: `"${APP_NAME}" <${FROM_ADDRESS}>`,
+      to: toEmail,
+      subject: `Reset your ${APP_NAME} password`,
+      text,
+      html,
+    });
+
+    // In dev the jsonTransport serialises the message — log it for inspection
+    if (process.env.NODE_ENV !== 'production') {
+      logger.info({ msg: 'Password reset email (dev)', messageId: info.messageId });
+    }
+  } catch (err) {
+    // Log but swallow — callers must not learn whether delivery succeeded
+    logger.error({ msg: 'Failed to send password reset email', error: err });
+  }
+}

--- a/backend/tests/services/password-reset.integration.test.ts
+++ b/backend/tests/services/password-reset.integration.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Integration tests — Password Reset Flow
+ *
+ * Covers:
+ *  1. forgot-password → reset link sent (always same response)
+ *  2. reset-password  → password updated successfully
+ *  3. Old session token rejected after reset
+ *  4. New login succeeds with new password
+ *  5. Expired token rejected
+ *  6. Already-used token rejected (replay attack)
+ */
+
+import jwt from 'jsonwebtoken';
+import bcrypt from 'bcrypt';
+import {
+  forgotPassword,
+  resetPassword,
+  login,
+  isSessionRevoked,
+  users,
+} from '../../src/services/auth.service';
+
+// ---------------------------------------------------------------------------
+// Mock email service so no real SMTP calls are made
+// ---------------------------------------------------------------------------
+jest.mock('../../src/services/email.service', () => ({
+  sendPasswordResetEmail: jest.fn().mockResolvedValue(undefined),
+}));
+import { sendPasswordResetEmail } from '../../src/services/email.service';
+
+// ---------------------------------------------------------------------------
+// Mock Redis so tests run without a live Redis instance
+// ---------------------------------------------------------------------------
+const redisStore = new Map<string, string>();
+jest.mock('../../src/services/cache.service', () => ({
+  redis: {
+    set: jest.fn(async (key: string, value: string) => { redisStore.set(key, value); }),
+    get: jest.fn(async (key: string) => redisStore.get(key) ?? null),
+    incr: jest.fn(async (key: string) => {
+      const v = parseInt(redisStore.get(key) ?? '0', 10) + 1;
+      redisStore.set(key, String(v));
+      return v;
+    }),
+    expire: jest.fn().mockResolvedValue(1),
+    ttl: jest.fn().mockResolvedValue(60),
+  },
+}));
+
+const JWT_SECRET = process.env.JWT_SECRET ?? 'dev-jwt-secret-change-me';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+async function createTestUser(email: string, password: string) {
+  const id = `user-${Date.now()}-${Math.random()}`;
+  const passwordHash = await bcrypt.hash(password, 10);
+  users.set(id, {
+    id,
+    email,
+    passwordHash,
+    twoFactorEnabled: false,
+    sessionVersion: 0,
+  });
+  return id;
+}
+
+/** Extract the reset token that was passed to sendPasswordResetEmail */
+function captureResetToken(): string {
+  const mock = sendPasswordResetEmail as jest.Mock;
+  const calls = mock.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1][1] as string;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('Password Reset Flow', () => {
+  beforeEach(() => {
+    users.clear();
+    redisStore.clear();
+    (sendPasswordResetEmail as jest.Mock).mockClear();
+  });
+
+  // ── 1. forgot-password always returns the same response ─────────────────
+  describe('forgotPassword()', () => {
+    it('does not throw and sends email when user exists', async () => {
+      await createTestUser('alice@example.com', 'OldPass123!');
+      await expect(forgotPassword('alice@example.com')).resolves.toBeUndefined();
+      expect(sendPasswordResetEmail).toHaveBeenCalledTimes(1);
+      expect(sendPasswordResetEmail).toHaveBeenCalledWith(
+        'alice@example.com',
+        expect.any(String),
+      );
+    });
+
+    it('does not throw and sends NO email when user does not exist (enumeration prevention)', async () => {
+      await expect(forgotPassword('nobody@example.com')).resolves.toBeUndefined();
+      expect(sendPasswordResetEmail).not.toHaveBeenCalled();
+    });
+
+    it('stores a resetTokenHash on the user record', async () => {
+      const id = await createTestUser('bob@example.com', 'OldPass123!');
+      await forgotPassword('bob@example.com');
+      const user = users.get(id)!;
+      expect(user.resetTokenHash).toBeDefined();
+      expect(typeof user.resetTokenHash).toBe('string');
+    });
+
+    it('issues a JWT with type=password_reset and 15-minute expiry', async () => {
+      await createTestUser('carol@example.com', 'OldPass123!');
+      await forgotPassword('carol@example.com');
+      const token = captureResetToken();
+      const payload = jwt.verify(token, JWT_SECRET) as jwt.JwtPayload;
+      expect(payload.type).toBe('password_reset');
+      // exp should be ~15 min from now (within a 5-second tolerance)
+      const nowSec = Math.floor(Date.now() / 1000);
+      expect(payload.exp).toBeGreaterThan(nowSec + 14 * 60);
+      expect(payload.exp).toBeLessThanOrEqual(nowSec + 15 * 60 + 5);
+    });
+  });
+
+  // ── 2. reset-password updates the password ───────────────────────────────
+  describe('resetPassword()', () => {
+    it('updates the password hash on success', async () => {
+      const id = await createTestUser('dave@example.com', 'OldPass123!');
+      await forgotPassword('dave@example.com');
+      const token = captureResetToken();
+
+      await resetPassword(token, 'NewPass456!');
+
+      const user = users.get(id)!;
+      const matches = await bcrypt.compare('NewPass456!', user.passwordHash);
+      expect(matches).toBe(true);
+    });
+
+    it('clears resetTokenHash after use', async () => {
+      const id = await createTestUser('eve@example.com', 'OldPass123!');
+      await forgotPassword('eve@example.com');
+      const token = captureResetToken();
+
+      await resetPassword(token, 'NewPass456!');
+
+      const user = users.get(id)!;
+      expect(user.resetTokenHash).toBeUndefined();
+    });
+
+    it('increments sessionVersion on success', async () => {
+      const id = await createTestUser('frank@example.com', 'OldPass123!');
+      const versionBefore = users.get(id)!.sessionVersion;
+
+      await forgotPassword('frank@example.com');
+      const token = captureResetToken();
+      await resetPassword(token, 'NewPass456!');
+
+      const versionAfter = users.get(id)!.sessionVersion;
+      expect(versionAfter).toBe(versionBefore + 1);
+    });
+  });
+
+  // ── 3. Old session rejected after reset ──────────────────────────────────
+  describe('Session invalidation', () => {
+    it('marks old session version as revoked in Redis', async () => {
+      const id = await createTestUser('grace@example.com', 'OldPass123!');
+      const oldVersion = users.get(id)!.sessionVersion; // 0
+
+      await forgotPassword('grace@example.com');
+      const token = captureResetToken();
+      await resetPassword(token, 'NewPass456!');
+
+      const revoked = await isSessionRevoked(id, oldVersion);
+      expect(revoked).toBe(true);
+    });
+
+    it('does not revoke the new session version', async () => {
+      const id = await createTestUser('henry@example.com', 'OldPass123!');
+
+      await forgotPassword('henry@example.com');
+      const token = captureResetToken();
+      await resetPassword(token, 'NewPass456!');
+
+      const newVersion = users.get(id)!.sessionVersion;
+      const revoked = await isSessionRevoked(id, newVersion);
+      expect(revoked).toBe(false);
+    });
+  });
+
+  // ── 4. New login succeeds with new password ───────────────────────────────
+  describe('Login after reset', () => {
+    it('allows login with the new password', async () => {
+      await createTestUser('iris@example.com', 'OldPass123!');
+      await forgotPassword('iris@example.com');
+      const token = captureResetToken();
+      await resetPassword(token, 'NewPass456!');
+
+      const result = await login('iris@example.com', 'NewPass456!');
+      expect(result).toHaveProperty('accessToken');
+      expect(result).toHaveProperty('refreshToken');
+    });
+
+    it('rejects login with the old password after reset', async () => {
+      await createTestUser('jack@example.com', 'OldPass123!');
+      await forgotPassword('jack@example.com');
+      const token = captureResetToken();
+      await resetPassword(token, 'NewPass456!');
+
+      await expect(login('jack@example.com', 'OldPass123!')).rejects.toMatchObject({
+        statusCode: 401,
+      });
+    });
+  });
+
+  // ── 5. Expired token rejected ─────────────────────────────────────────────
+  describe('Expired token', () => {
+    it('rejects a token with exp in the past', async () => {
+      const id = await createTestUser('kate@example.com', 'OldPass123!');
+
+      // Manually craft an already-expired reset token
+      const expiredToken = jwt.sign(
+        { sub: id, type: 'password_reset' },
+        JWT_SECRET,
+        { expiresIn: -1 }, // expired 1 second ago
+      );
+
+      // Store its hash so the single-use check doesn't fire first
+      const { createHash } = await import('crypto');
+      const hash = createHash('sha256').update(expiredToken).digest('hex');
+      users.get(id)!.resetTokenHash = hash;
+
+      await expect(resetPassword(expiredToken, 'NewPass456!')).rejects.toMatchObject({
+        statusCode: 400,
+        message: 'Invalid or expired reset token',
+      });
+    });
+  });
+
+  // ── 6. Already-used token rejected (replay attack) ───────────────────────
+  describe('Single-use enforcement', () => {
+    it('rejects a token that has already been consumed', async () => {
+      await createTestUser('liam@example.com', 'OldPass123!');
+      await forgotPassword('liam@example.com');
+      const token = captureResetToken();
+
+      // First use — should succeed
+      await resetPassword(token, 'NewPass456!');
+
+      // Second use — must be rejected
+      await expect(resetPassword(token, 'AnotherPass789!')).rejects.toMatchObject({
+        statusCode: 400,
+      });
+    });
+
+    it('rejects a token when no resetTokenHash is stored (already consumed)', async () => {
+      const id = await createTestUser('mia@example.com', 'OldPass123!');
+
+      // Issue a valid token but do NOT store its hash (simulates post-use state)
+      const token = jwt.sign(
+        { sub: id, type: 'password_reset' },
+        JWT_SECRET,
+        { expiresIn: '15m' },
+      );
+      // resetTokenHash is undefined by default
+
+      await expect(resetPassword(token, 'NewPass456!')).rejects.toMatchObject({
+        statusCode: 400,
+        message: 'Reset token has already been used',
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Add POST /auth/forgot-password (enumeration-safe, always same response)
- Add POST /auth/reset-password (validates JWT, single-use hash, bcrypt)
- New email.service.ts sends HTML reset email via nodemailer; SMTP failures swallowed to prevent info leakage
- Session invalidation via sessionVersion bump + Redis tombstones so in-flight tokens are rejected immediately after reset
- Stricter rate limits on both new endpoints (5-10 req / 15 min / IP)
- Install bcrypt + nodemailer with TypeScript types
- 14 integration tests; full suite 43/43 green, tsc --noEmit clean

## Closes

Closes #

## What this PR does

<!-- One paragraph. What did you implement? Do not explain how — the code does that. -->

## Testing

<!-- How did you verify this works? What test cases did you add? -->

## Screenshots (frontend changes only)

<!-- Add before/after screenshots or a short screen recording. -->

## Checklist

- [ ] I have read `docs/contributing.md`
- [ ] My code follows the naming conventions in the guidelines
- [ ] I have added or updated tests for my changes
- [ ] All tests pass locally (`cargo test` / `npm test`)
- [ ] Lint passes (`cargo clippy` / `npm run lint`)
- [ ] No `console.log` or `unwrap()` left in production paths
- [ ] No secrets committed


closes #447 