### PR TITLE
feat: Redis caching, MarketService tests, indexer integration tests, Pino logging (#35 #36 #37 #38)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -25,6 +25,7 @@ REDIS_URL=redis://localhost:6379
 PORT=3001
 JWT_SECRET=change-me-in-production
 ORACLE_API_KEY=change-me-in-production
+LOG_LEVEL=info
 
 # ── Indexer ───────────────────────────────────────────────────
 GENESIS_LEDGER=100000

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -1,0 +1,57 @@
+CREATE TABLE IF NOT EXISTS markets (
+  id               SERIAL PRIMARY KEY,
+  market_id        TEXT        NOT NULL UNIQUE,
+  contract_address TEXT        NOT NULL,
+  match_id         TEXT        NOT NULL,
+  fighter_a        TEXT        NOT NULL,
+  fighter_b        TEXT        NOT NULL,
+  weight_class     TEXT        NOT NULL DEFAULT '',
+  title_fight      BOOLEAN     NOT NULL DEFAULT FALSE,
+  venue            TEXT        NOT NULL DEFAULT '',
+  scheduled_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  status           TEXT        NOT NULL DEFAULT 'open',
+  outcome          TEXT,
+  pool_a           NUMERIC     NOT NULL DEFAULT 0,
+  pool_b           NUMERIC     NOT NULL DEFAULT 0,
+  pool_draw        NUMERIC     NOT NULL DEFAULT 0,
+  total_pool       NUMERIC     NOT NULL DEFAULT 0,
+  fee_bps          INTEGER     NOT NULL DEFAULT 200,
+  resolved_at      TIMESTAMPTZ,
+  oracle_used      TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  ledger_sequence  INTEGER     NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS bets (
+  id               SERIAL PRIMARY KEY,
+  market_id        TEXT        NOT NULL REFERENCES markets(market_id),
+  bettor_address   TEXT        NOT NULL,
+  side             TEXT        NOT NULL,
+  amount           NUMERIC     NOT NULL,
+  amount_xlm       NUMERIC     NOT NULL DEFAULT 0,
+  placed_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  claimed          BOOLEAN     NOT NULL DEFAULT FALSE,
+  claimed_at       TIMESTAMPTZ,
+  payout           NUMERIC,
+  tx_hash          TEXT        NOT NULL UNIQUE,
+  ledger_sequence  INTEGER     NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS blockchain_events (
+  id                SERIAL PRIMARY KEY,
+  contract_address  TEXT        NOT NULL,
+  event_type        TEXT        NOT NULL,
+  payload           JSONB       NOT NULL DEFAULT '{}',
+  ledger_sequence   INTEGER     NOT NULL,
+  ledger_close_time TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  tx_hash           TEXT        NOT NULL UNIQUE,
+  processed         BOOLEAN     NOT NULL DEFAULT FALSE,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS indexer_checkpoints (
+  id                      SERIAL PRIMARY KEY,
+  last_processed_ledger   INTEGER     NOT NULL,
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,6 +12,7 @@
         "ioredis": "^5.10.1",
         "jsonwebtoken": "^9.0.3",
         "otpauth": "^9.5.0",
+        "pg": "^8.20.0",
         "qrcode": "^1.5.4",
         "winston": "^3.13.0"
       },
@@ -22,6 +23,7 @@
         "@types/jest": "^29.5.12",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.14.0",
+        "@types/pg": "^8.20.0",
         "@types/qrcode": "^1.5.6",
         "@typescript-eslint/eslint-plugin": "^7.13.0",
         "@typescript-eslint/parser": "^7.13.0",
@@ -1581,6 +1583,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/qrcode": {
@@ -5868,6 +5882,95 @@
         "node": ">=8"
       }
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5984,6 +6087,45 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -6770,6 +6912,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -7613,7 +7764,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,8 @@
         "jsonwebtoken": "^9.0.3",
         "otpauth": "^9.5.0",
         "pg": "^8.20.0",
+        "pino": "^10.3.1",
+        "pino-http": "^11.0.0",
         "qrcode": "^1.5.4",
         "winston": "^3.13.0"
       },
@@ -24,11 +26,13 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20.14.0",
         "@types/pg": "^8.20.0",
+        "@types/pino-http": "^5.8.4",
         "@types/qrcode": "^1.5.6",
         "@typescript-eslint/eslint-plugin": "^7.13.0",
         "@typescript-eslint/parser": "^7.13.0",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
+        "pino-pretty": "^13.1.3",
         "ts-jest": "^29.1.5",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
@@ -1275,6 +1279,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -1595,6 +1605,60 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pino": {
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.12.tgz",
+      "integrity": "sha512-dsLRTq8/4UtVSpJgl9aeqHvbh6pzdmjYD3C092SYgLD2TyoCqHpTJk6vp8DvCTGGc7iowZ2MoiYiVUUCcu7muw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pino-pretty": "*",
+        "@types/pino-std-serializers": "*",
+        "sonic-boom": "^2.1.0"
+      }
+    },
+    "node_modules/@types/pino-http": {
+      "version": "5.8.4",
+      "resolved": "https://registry.npmjs.org/@types/pino-http/-/pino-http-5.8.4.tgz",
+      "integrity": "sha512-UTYBQ2acmJ2eK0w58vVtgZ9RAicFFndfrnWC1w5cBTf8zwn/HEy8O+H7psc03UZgTzHmlcuX8VkPRnRDEj+FUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/pino": "6.3"
+      }
+    },
+    "node_modules/@types/pino-pretty": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.5.tgz",
+      "integrity": "sha512-rfHe6VIknk14DymxGqc9maGsRe8/HQSvM2u46EAz2XrS92qsAJnW16dpdFejBuZKD8cRJX6Aw6uVZqIQctMpAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pino": "6.3"
+      }
+    },
+    "node_modules/@types/pino-std-serializers": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz",
+      "integrity": "sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/pino/node_modules/sonic-boom": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/@types/qrcode": {
@@ -2073,6 +2137,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -2759,6 +2832,13 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2874,6 +2954,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -3130,6 +3220,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/error-ex": {
@@ -3536,6 +3636,13 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3584,6 +3691,13 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4115,6 +4229,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -5114,6 +5235,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5659,6 +5790,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -5991,6 +6131,93 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-http": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-11.0.0.tgz",
+      "integrity": "sha512-wqg5XIAGRRIWtTk8qPGxkbrfiwEWz1lgedVLvhLALudKXvg1/L2lTFgTGPJ4Z2e3qcRmxoFxDuSdMdMGNM6I1g==",
+      "license": "MIT",
+      "dependencies": {
+        "get-caller-file": "^2.0.5",
+        "pino": "^10.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -6166,6 +6393,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -6201,6 +6444,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -6401,6 +6655,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6467,6 +6727,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redis-errors": {
@@ -6656,6 +6925,23 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -6891,6 +7177,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/source-map": {
@@ -7136,6 +7431,18 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,8 @@
     "jsonwebtoken": "^9.0.3",
     "otpauth": "^9.5.0",
     "pg": "^8.20.0",
+    "pino": "^10.3.1",
+    "pino-http": "^11.0.0",
     "qrcode": "^1.5.4",
     "winston": "^3.13.0"
   },
@@ -26,11 +28,13 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.14.0",
     "@types/pg": "^8.20.0",
+    "@types/pino-http": "^5.8.4",
     "@types/qrcode": "^1.5.6",
     "@typescript-eslint/eslint-plugin": "^7.13.0",
     "@typescript-eslint/parser": "^7.13.0",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
+    "pino-pretty": "^13.1.3",
     "ts-jest": "^29.1.5",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.5"

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,13 +6,15 @@
     "dev": "ts-node-dev --respawn src/index.ts",
     "build": "tsc --noEmit",
     "lint": "eslint 'src/**/*.ts' 'tests/**/*.ts'",
-    "test": "jest --passWithNoTests"
+    "test": "jest --passWithNoTests",
+    "test:integration": "jest --passWithNoTests --testPathPatterns=tests/integration"
   },
   "dependencies": {
     "express": "^4.19.2",
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.3",
     "otpauth": "^9.5.0",
+    "pg": "^8.20.0",
     "qrcode": "^1.5.4",
     "winston": "^3.13.0"
   },
@@ -23,6 +25,7 @@
     "@types/jest": "^29.5.12",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20.14.0",
+    "@types/pg": "^8.20.0",
     "@types/qrcode": "^1.5.6",
     "@typescript-eslint/eslint-plugin": "^7.13.0",
     "@typescript-eslint/parser": "^7.13.0",

--- a/backend/src/config/db.ts
+++ b/backend/src/config/db.ts
@@ -1,0 +1,5 @@
+import { Pool } from 'pg';
+
+const DATABASE_URL = process.env.DATABASE_URL ?? 'postgresql://boxmeout:boxmeout@localhost:5432/boxmeout';
+
+export const pool = new Pool({ connectionString: DATABASE_URL });

--- a/backend/src/config/redis.ts
+++ b/backend/src/config/redis.ts
@@ -1,0 +1,5 @@
+import Redis from 'ioredis';
+
+const REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379';
+
+export const redis = new Redis(REDIS_URL, { lazyConnect: true });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import pinoHttp from "pino-http";
 import { errorMiddleware } from "./middleware/error.middleware";
 import { rateLimit } from "./middleware/rate-limit.middleware";
 import { AppError } from "./utils/AppError";
@@ -8,6 +9,7 @@ import authRouter from "./routes/auth.routes";
 const app = express();
 
 // Middleware
+app.use(pinoHttp({ logger }));
 app.use(express.json());
 
 // Routes

--- a/backend/src/indexer/StellarIndexer.ts
+++ b/backend/src/indexer/StellarIndexer.ts
@@ -10,6 +10,7 @@
 // ============================================================
 
 import type { BlockchainEvent } from '../models/BlockchainEvent';
+import { pool } from '../config/db';
 
 // Raw event shape returned by Stellar RPC / Horizon
 export interface RawStellarEvent {
@@ -22,142 +23,152 @@ export interface RawStellarEvent {
   tx_hash: string;
 }
 
-/**
- * Entry point for the indexer process.
- *
- * Steps:
- *   1. Load last processed ledger via getLastProcessedLedger()
- *   2. Enter infinite loop:
- *      a. Fetch next ledger(s) from Stellar RPC
- *      b. Call processLedger() for each new ledger
- *      c. Call saveCheckpoint() after each successful ledger
- *      d. Sleep for POLL_INTERVAL_MS if no new ledgers
- *   3. On unrecoverable error: log and exit (let process manager restart)
- *
- * Should be called once at process startup.
- */
 export async function startIndexer(): Promise<void> {
   // TODO: implement
 }
 
-/**
- * Fetches all contract events emitted in a single Stellar ledger.
- * Filters to only known contract addresses (factory, all markets, treasury).
- * Calls processEvent() for each event.
- * Events must be processed in ledger order.
- */
 export async function processLedger(ledger_sequence: number): Promise<void> {
   // TODO: implement
 }
 
-/**
- * Routes a raw blockchain event to the correct domain handler.
- *
- * Routing table:
- *   "MarketCreated"    → handleMarketCreated()
- *   "BetPlaced"        → handleBetPlaced()
- *   "MarketLocked"     → handleMarketLocked()
- *   "MarketResolved"   → handleMarketResolved()
- *   "MarketCancelled"  → handleMarketCancelled()
- *   "WinningsClaimed"  → handleWinningsClaimed()
- *   unknown type       → log warning, skip
- *
- * Persists the raw event to BlockchainEvent table regardless of handler outcome.
- * Marks event.processed = true only after handler succeeds without throwing.
- */
 export async function processEvent(event: RawStellarEvent): Promise<void> {
   // TODO: implement
 }
 
-/**
- * Handles a MarketCreated event from the MarketFactory contract.
- *
- * Parses event payload to extract: market_id, contract_address, match_id,
- * fighter_a, fighter_b, weight_class, scheduled_at, fee_bps, etc.
- * Inserts a new Market row with status = "open".
- */
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parsePayload(data: string): Record<string, unknown> {
+  try { return JSON.parse(data); } catch { return {}; }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
 export async function handleMarketCreated(event: RawStellarEvent): Promise<void> {
-  // TODO: implement
+  const p = parsePayload(event.data);
+  await pool.query(
+    `INSERT INTO markets
+       (market_id, contract_address, match_id, fighter_a, fighter_b,
+        weight_class, title_fight, venue, scheduled_at, fee_bps, ledger_sequence)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+     ON CONFLICT (market_id) DO NOTHING`,
+    [
+      p.market_id,
+      event.contract_address,
+      p.match_id ?? '',
+      p.fighter_a ?? '',
+      p.fighter_b ?? '',
+      p.weight_class ?? '',
+      p.title_fight ?? false,
+      p.venue ?? '',
+      p.scheduled_at ?? new Date(),
+      p.fee_bps ?? 200,
+      event.ledger_sequence,
+    ],
+  );
 }
 
-/**
- * Handles a BetPlaced event from a Market contract.
- *
- * Parses: bettor_address, market_id, side, amount, placed_at, tx_hash.
- * Inserts a Bet row.
- * Updates Market.pool_a / pool_b / pool_draw / total_pool in DB.
- */
 export async function handleBetPlaced(event: RawStellarEvent): Promise<void> {
-  // TODO: implement
+  const p = parsePayload(event.data);
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `INSERT INTO bets
+         (market_id, bettor_address, side, amount, amount_xlm, placed_at, tx_hash, ledger_sequence)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+       ON CONFLICT (tx_hash) DO NOTHING`,
+      [
+        p.market_id,
+        p.bettor_address,
+        p.side,
+        p.amount,
+        Number(p.amount) / 10_000_000,
+        p.placed_at ?? new Date(),
+        event.tx_hash,
+        event.ledger_sequence,
+      ],
+    );
+    const col = p.side === 'fighter_a' ? 'pool_a' : p.side === 'fighter_b' ? 'pool_b' : 'pool_draw';
+    await client.query(
+      `UPDATE markets
+          SET ${col}      = ${col} + $1,
+              total_pool  = total_pool + $1,
+              updated_at  = NOW()
+        WHERE market_id   = $2`,
+      [p.amount, p.market_id],
+    );
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
 }
 
-/**
- * Handles a MarketLocked event.
- * Updates Market.status = "locked" for the given market_id.
- */
 export async function handleMarketLocked(event: RawStellarEvent): Promise<void> {
-  // TODO: implement
+  const p = parsePayload(event.data);
+  await pool.query(
+    `UPDATE markets SET status = 'locked', updated_at = NOW() WHERE market_id = $1`,
+    [p.market_id],
+  );
 }
 
-/**
- * Handles a MarketResolved event.
- *
- * Updates Market.status = "resolved", Market.outcome, Market.resolved_at,
- * and Market.oracle_used from the event payload.
- * Enqueues a push notification job for all bettors in this market.
- */
 export async function handleMarketResolved(event: RawStellarEvent): Promise<void> {
-  // TODO: implement
+  const p = parsePayload(event.data);
+  await pool.query(
+    `UPDATE markets
+        SET status = 'resolved', outcome = $1, resolved_at = $2, oracle_used = $3, updated_at = NOW()
+      WHERE market_id = $4`,
+    [p.outcome, p.resolved_at ?? new Date(), p.oracle_used ?? null, p.market_id],
+  );
 }
 
-/**
- * Handles a MarketCancelled event.
- * Updates Market.status = "cancelled".
- * Enqueues refund-available notifications for all bettors.
- */
 export async function handleMarketCancelled(event: RawStellarEvent): Promise<void> {
-  // TODO: implement
+  const p = parsePayload(event.data);
+  await pool.query(
+    `UPDATE markets SET status = 'cancelled', updated_at = NOW() WHERE market_id = $1`,
+    [p.market_id],
+  );
 }
 
-/**
- * Handles a WinningsClaimed event.
- *
- * Marks all Bet rows for this (bettor_address, market_id) pair as claimed.
- * Stores the actual payout amount from the event payload.
- */
 export async function handleWinningsClaimed(event: RawStellarEvent): Promise<void> {
-  // TODO: implement
+  const p = parsePayload(event.data);
+  await pool.query(
+    `UPDATE bets
+        SET claimed = TRUE, claimed_at = NOW(), payout = $1
+      WHERE market_id = $2 AND bettor_address = $3`,
+    [p.payout ?? null, p.market_id, p.bettor_address],
+  );
 }
 
-/**
- * Returns the ledger sequence of the last successfully processed ledger.
- * Reads from the indexer_checkpoints table.
- * Returns GENESIS_LEDGER constant if no checkpoint exists yet.
- */
 export async function getLastProcessedLedger(): Promise<number> {
-  // TODO: implement
-  throw new Error('Not implemented');
+  const { rows } = await pool.query(
+    `SELECT last_processed_ledger FROM indexer_checkpoints ORDER BY id DESC LIMIT 1`,
+  );
+  return rows[0]?.last_processed_ledger ?? Number(process.env.GENESIS_LEDGER ?? 0);
 }
 
-/**
- * Persists the latest successfully processed ledger sequence to DB.
- * Called after every successful processLedger() to allow safe restart.
- */
 export async function saveCheckpoint(ledger_sequence: number): Promise<void> {
-  // TODO: implement
+  await pool.query(
+    `INSERT INTO indexer_checkpoints (last_processed_ledger) VALUES ($1)`,
+    [ledger_sequence],
+  );
 }
 
-/**
- * Reprocesses a historical range of ledgers.
- * Used for reindexing after a DB reset or missed event window.
- *
- * Processes ledgers in ascending order, in batches of batch_size.
- * Existing DB rows for those ledgers should be upserted (not duplicated).
- */
 export async function backfillLedgerRange(
   from_ledger: number,
   to_ledger: number,
   batch_size: number,
 ): Promise<void> {
-  // TODO: implement
+  for (let l = from_ledger; l <= to_ledger; l += batch_size) {
+    const end = Math.min(l + batch_size - 1, to_ledger);
+    for (let seq = l; seq <= end; seq++) {
+      await processLedger(seq);
+    }
+  }
 }

--- a/backend/src/services/MarketService.ts
+++ b/backend/src/services/MarketService.ts
@@ -6,6 +6,7 @@
 
 import type { Market, MarketStats } from '../models/Market';
 import type { Bet } from '../models/Bet';
+import { cacheGet, cacheSet } from './cache.service';
 
 export interface MarketFilters {
   status?: string;
@@ -52,7 +53,13 @@ export async function getMarkets(
   filters?: MarketFilters,
   pagination?: Pagination,
 ): Promise<MarketListResult> {
-  // TODO: implement
+  const cacheKey = `markets:${JSON.stringify(filters ?? {})}:${JSON.stringify(pagination ?? {})}`;
+  const cached = await cacheGet<MarketListResult>(cacheKey);
+  if (cached) return cached;
+
+  // TODO: query DB, build result, then:
+  // await cacheSet(cacheKey, result, 30);
+  // return result;
   throw new Error('Not implemented');
 }
 
@@ -95,7 +102,13 @@ export async function getBetsByMarket(
  * Results cached in Redis for 60 seconds.
  */
 export async function getMarketStats(market_id: string): Promise<MarketStats> {
-  // TODO: implement
+  const cacheKey = `market:${market_id}:stats`;
+  const cached = await cacheGet<MarketStats>(cacheKey);
+  if (cached) return cached;
+
+  // TODO: compute stats from bets table, then:
+  // await cacheSet(cacheKey, stats, 60);
+  // return stats;
   throw new Error('Not implemented');
 }
 

--- a/backend/src/services/MarketService.ts
+++ b/backend/src/services/MarketService.ts
@@ -7,6 +7,27 @@
 import type { Market, MarketStats } from '../models/Market';
 import type { Bet } from '../models/Bet';
 import { cacheGet, cacheSet } from './cache.service';
+import { AppError } from '../utils/AppError';
+
+// ---------------------------------------------------------------------------
+// DB adapter — thin abstraction so tests can inject a mock
+// ---------------------------------------------------------------------------
+export interface DbAdapter {
+  findMarkets(filters?: MarketFilters): Promise<Market[]>;
+  findMarketById(market_id: string): Promise<Market | null>;
+  findBetsByAddress(bettor_address: string): Promise<Bet[]>;
+}
+
+let _db: DbAdapter | null = null;
+
+export function setDbAdapter(adapter: DbAdapter): void {
+  _db = adapter;
+}
+
+function db(): DbAdapter {
+  if (!_db) throw new Error('DbAdapter not initialised');
+  return _db;
+}
 
 export interface MarketFilters {
   status?: string;
@@ -57,10 +78,23 @@ export async function getMarkets(
   const cached = await cacheGet<MarketListResult>(cacheKey);
   if (cached) return cached;
 
-  // TODO: query DB, build result, then:
-  // await cacheSet(cacheKey, result, 30);
-  // return result;
-  throw new Error('Not implemented');
+  let markets = await db().findMarkets(filters);
+
+  if (filters?.status) markets = markets.filter(m => m.status === filters.status);
+  if (filters?.weight_class) markets = markets.filter(m => m.weight_class === filters.weight_class);
+
+  markets = [...markets].sort(
+    (a, b) => new Date(a.scheduled_at).getTime() - new Date(b.scheduled_at).getTime(),
+  );
+
+  const page = pagination?.page ?? 1;
+  const limit = pagination?.limit ?? markets.length;
+  const offset = (page - 1) * limit;
+  const paged = markets.slice(offset, offset + limit);
+
+  const result: MarketListResult = { markets: paged, total: markets.length };
+  await cacheSet(cacheKey, result, 30);
+  return result;
 }
 
 /**
@@ -68,8 +102,9 @@ export async function getMarkets(
  * Throws NotFoundError (HTTP 404) if market_id does not exist in DB.
  */
 export async function getMarketById(market_id: string): Promise<Market> {
-  // TODO: implement
-  throw new Error('Not implemented');
+  const market = await db().findMarketById(market_id);
+  if (!market) throw new AppError(404, `Market not found: ${market_id}`);
+  return market;
 }
 
 /**
@@ -80,8 +115,17 @@ export async function getMarketById(market_id: string): Promise<Market> {
  * if DB pool sizes are stale (updated_at older than 30 seconds).
  */
 export async function getMarketOdds(market_id: string): Promise<MarketOdds> {
-  // TODO: implement
-  throw new Error('Not implemented');
+  const market = await db().findMarketById(market_id);
+  if (!market) throw new AppError(404, `Market not found: ${market_id}`);
+
+  const total = Number(market.total_pool);
+  if (total === 0) return { odds_a: 0, odds_b: 0, odds_draw: 0 };
+
+  return {
+    odds_a: Math.floor(Number(market.pool_a) * 10_000 / total),
+    odds_b: Math.floor(Number(market.pool_b) * 10_000 / total),
+    odds_draw: Math.floor(Number(market.pool_draw) * 10_000 / total),
+  };
 }
 
 /**
@@ -123,8 +167,43 @@ export async function getMarketStats(market_id: string): Promise<MarketStats> {
 export async function getPortfolioByAddress(
   bettor_address: string,
 ): Promise<Portfolio> {
-  // TODO: implement
-  throw new Error('Not implemented');
+  const bets = await db().findBetsByAddress(bettor_address);
+  const marketIds = [...new Set(bets.map(b => b.market_id))];
+  const markets = await Promise.all(marketIds.map(id => db().findMarketById(id)));
+  const marketMap = new Map(markets.filter(Boolean).map(m => [m!.market_id, m!]));
+
+  const active_bets: Bet[] = [];
+  const past_bets: Bet[] = [];
+  const pending_claims: Bet[] = [];
+
+  for (const bet of bets) {
+    const market = marketMap.get(bet.market_id);
+    const status = market?.status;
+    if (status === 'open' || status === 'locked') {
+      active_bets.push(bet);
+    } else {
+      past_bets.push(bet);
+      if (status === 'resolved' && !bet.claimed) pending_claims.push(bet);
+    }
+  }
+
+  const total_staked_xlm = bets.reduce((s, b) => s + Number(b.amount) / 10_000_000, 0);
+  const total_won_xlm = bets
+    .filter(b => b.claimed && b.payout)
+    .reduce((s, b) => s + Number(b.payout) / 10_000_000, 0);
+  const total_lost_xlm = past_bets
+    .filter(b => !b.claimed && !pending_claims.includes(b))
+    .reduce((s, b) => s + Number(b.amount) / 10_000_000, 0);
+
+  return {
+    address: bettor_address,
+    active_bets,
+    past_bets,
+    total_staked_xlm,
+    total_won_xlm,
+    total_lost_xlm,
+    pending_claims,
+  };
 }
 
 /**

--- a/backend/src/services/cache.service.ts
+++ b/backend/src/services/cache.service.ts
@@ -1,5 +1,19 @@
-import Redis from 'ioredis';
+import { redis } from '../config/redis';
 
-const REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379';
+export async function cacheGet<T>(key: string): Promise<T | null> {
+  const data = await redis.get(key);
+  return data ? (JSON.parse(data) as T) : null;
+}
 
-export const redis = new Redis(REDIS_URL, { lazyConnect: true });
+export async function cacheSet(key: string, value: unknown, ttl_seconds: number): Promise<void> {
+  await redis.set(key, JSON.stringify(value), 'EX', ttl_seconds);
+}
+
+export async function cacheDelete(key: string): Promise<void> {
+  await redis.del(key);
+}
+
+export async function cacheDeletePattern(pattern: string): Promise<void> {
+  const keys = await redis.keys(pattern);
+  if (keys.length > 0) await redis.del(...keys);
+}

--- a/backend/src/services/cache.service.ts
+++ b/backend/src/services/cache.service.ts
@@ -1,5 +1,7 @@
 import { redis } from '../config/redis';
 
+export { redis };
+
 export async function cacheGet<T>(key: string): Promise<T | null> {
   const data = await redis.get(key);
   return data ? (JSON.parse(data) as T) : null;

--- a/backend/src/utils/__mocks__/logger.ts
+++ b/backend/src/utils/__mocks__/logger.ts
@@ -1,0 +1,6 @@
+export const logger = {
+  info: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  debug: jest.fn(),
+};

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,7 +1,10 @@
-import { createLogger, format, transports } from 'winston';
+import pino from 'pino';
 
-export const logger = createLogger({
-  level: 'info',
-  format: format.combine(format.timestamp(), format.json()),
-  transports: [new transports.Console()],
+const isDev = process.env.NODE_ENV !== 'production';
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL ?? 'info',
+  ...(isDev && {
+    transport: { target: 'pino-pretty', options: { colorize: true } },
+  }),
 });

--- a/backend/tests/integration/indexer.test.ts
+++ b/backend/tests/integration/indexer.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Integration tests for StellarIndexer handlers.
+ *
+ * Requires a running PostgreSQL instance pointed to by DATABASE_URL.
+ * Default: postgresql://boxmeout:boxmeout@localhost:5433/boxmeout_test
+ * Start with: docker compose --profile test up -d postgres-test
+ */
+
+import { Pool } from 'pg';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  handleMarketCreated,
+  handleBetPlaced,
+  handleMarketResolved,
+  handleMarketCancelled,
+  handleWinningsClaimed,
+} from '../../src/indexer/StellarIndexer';
+
+// Point the pool at the test DB
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ?? 'postgresql://boxmeout:boxmeout@localhost:5433/boxmeout_test';
+
+// Re-import pool AFTER env is set
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { pool } = require('../../src/config/db') as { pool: Pool };
+
+const SCHEMA = fs.readFileSync(path.join(__dirname, '../../db/schema.sql'), 'utf8');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function event(type: string, data: Record<string, unknown>, txHash = `tx-${Math.random()}`) {
+  return {
+    contract_address: 'CTEST',
+    event_type: type,
+    topics: [],
+    data: JSON.stringify(data),
+    ledger_sequence: 1000,
+    ledger_close_time: new Date().toISOString(),
+    tx_hash: txHash,
+  };
+}
+
+async function q<T = Record<string, unknown>>(sql: string, params: unknown[] = []): Promise<T[]> {
+  const { rows } = await pool.query(sql, params);
+  return rows as T[];
+}
+
+const MARKET_ID = 'mkt-test-1';
+const BETTOR = 'GBETTOR1';
+
+const marketEvent = () =>
+  event('MarketCreated', {
+    market_id: MARKET_ID,
+    match_id: 'fight-1',
+    fighter_a: 'Ali',
+    fighter_b: 'Frazier',
+    weight_class: 'heavyweight',
+    title_fight: false,
+    venue: 'MSG',
+    scheduled_at: '2026-06-01T00:00:00Z',
+    fee_bps: 200,
+  });
+
+// ── Setup / teardown ─────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  await pool.query(SCHEMA);
+});
+
+beforeEach(async () => {
+  await pool.query('TRUNCATE markets, bets, blockchain_events, indexer_checkpoints RESTART IDENTITY CASCADE');
+});
+
+afterAll(async () => {
+  await pool.end();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('handleMarketCreated', () => {
+  it('inserts correct Market row', async () => {
+    await handleMarketCreated(marketEvent());
+    const [row] = await q('SELECT * FROM markets WHERE market_id = $1', [MARKET_ID]);
+    expect(row.market_id).toBe(MARKET_ID);
+    expect(row.fighter_a).toBe('Ali');
+    expect(row.fighter_b).toBe('Frazier');
+    expect(row.status).toBe('open');
+  });
+
+  it('is idempotent — duplicate event inserts no extra row', async () => {
+    const e = marketEvent();
+    await handleMarketCreated(e);
+    await handleMarketCreated(e);
+    const rows = await q('SELECT * FROM markets WHERE market_id = $1', [MARKET_ID]);
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe('handleBetPlaced', () => {
+  beforeEach(() => handleMarketCreated(marketEvent()));
+
+  it('inserts Bet and updates pool totals atomically', async () => {
+    await handleBetPlaced(
+      event('BetPlaced', { market_id: MARKET_ID, bettor_address: BETTOR, side: 'fighter_a', amount: '50000000' }, 'tx-bet-1'),
+    );
+    const [bet] = await q('SELECT * FROM bets WHERE tx_hash = $1', ['tx-bet-1']);
+    expect(bet.bettor_address).toBe(BETTOR);
+    expect(bet.side).toBe('fighter_a');
+
+    const [market] = await q('SELECT pool_a, total_pool FROM markets WHERE market_id = $1', [MARKET_ID]);
+    expect(Number(market.pool_a)).toBe(50_000_000);
+    expect(Number(market.total_pool)).toBe(50_000_000);
+  });
+
+  it('is idempotent — duplicate bet tx inserts no extra row', async () => {
+    const e = event('BetPlaced', { market_id: MARKET_ID, bettor_address: BETTOR, side: 'fighter_a', amount: '50000000' }, 'tx-bet-dup');
+    await handleBetPlaced(e);
+    await handleBetPlaced(e);
+    const rows = await q('SELECT * FROM bets WHERE tx_hash = $1', ['tx-bet-dup']);
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe('handleMarketResolved', () => {
+  beforeEach(() => handleMarketCreated(marketEvent()));
+
+  it('updates status and outcome', async () => {
+    await handleMarketResolved(
+      event('MarketResolved', { market_id: MARKET_ID, outcome: 'fighter_a', resolved_at: new Date().toISOString(), oracle_used: 'primary' }),
+    );
+    const [row] = await q('SELECT status, outcome, oracle_used FROM markets WHERE market_id = $1', [MARKET_ID]);
+    expect(row.status).toBe('resolved');
+    expect(row.outcome).toBe('fighter_a');
+    expect(row.oracle_used).toBe('primary');
+  });
+});
+
+describe('handleMarketCancelled', () => {
+  beforeEach(() => handleMarketCreated(marketEvent()));
+
+  it('updates status to cancelled', async () => {
+    await handleMarketCancelled(event('MarketCancelled', { market_id: MARKET_ID }));
+    const [row] = await q('SELECT status FROM markets WHERE market_id = $1', [MARKET_ID]);
+    expect(row.status).toBe('cancelled');
+  });
+});
+
+describe('handleWinningsClaimed', () => {
+  beforeEach(async () => {
+    await handleMarketCreated(marketEvent());
+    await handleBetPlaced(
+      event('BetPlaced', { market_id: MARKET_ID, bettor_address: BETTOR, side: 'fighter_a', amount: '50000000' }, 'tx-bet-claim'),
+    );
+  });
+
+  it('marks bets claimed with payout', async () => {
+    await handleWinningsClaimed(
+      event('WinningsClaimed', { market_id: MARKET_ID, bettor_address: BETTOR, payout: '95000000' }),
+    );
+    const [bet] = await q('SELECT claimed, payout FROM bets WHERE tx_hash = $1', ['tx-bet-claim']);
+    expect(bet.claimed).toBe(true);
+    expect(Number(bet.payout)).toBe(95_000_000);
+  });
+});

--- a/backend/tests/services/market.service.test.ts
+++ b/backend/tests/services/market.service.test.ts
@@ -1,0 +1,112 @@
+import { setDbAdapter, getMarkets, getMarketById, getMarketOdds, getPortfolioByAddress } from '../../src/services/MarketService';
+import { AppError } from '../../src/utils/AppError';
+import type { Market } from '../../src/models/Market';
+import type { Bet } from '../../src/models/Bet';
+
+// ── Mock cache so tests never touch Redis ────────────────────────────────────
+jest.mock('../../src/services/cache.service', () => ({
+  cacheGet: jest.fn().mockResolvedValue(null),
+  cacheSet: jest.fn().mockResolvedValue(undefined),
+}));
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+function makeMarket(overrides: Partial<Market> = {}): Market {
+  return {
+    id: 1,
+    market_id: 'mkt-1',
+    contract_address: 'C...',
+    match_id: 'fight-1',
+    fighter_a: 'Ali',
+    fighter_b: 'Frazier',
+    weight_class: 'heavyweight',
+    title_fight: false,
+    venue: 'MSG',
+    scheduled_at: new Date('2026-06-01T00:00:00Z'),
+    status: 'open',
+    outcome: null,
+    pool_a: '0',
+    pool_b: '0',
+    pool_draw: '0',
+    total_pool: '0',
+    fee_bps: 200,
+    resolved_at: null,
+    oracle_used: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ledger_sequence: 1000,
+    ...overrides,
+  };
+}
+
+const MARKET_OPEN = makeMarket({ market_id: 'mkt-1', status: 'open' });
+const MARKET_RESOLVED = makeMarket({ market_id: 'mkt-2', status: 'resolved' });
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe('MarketService', () => {
+  beforeEach(() => {
+    setDbAdapter({
+      findMarkets: jest.fn().mockResolvedValue([MARKET_OPEN, MARKET_RESOLVED]),
+      findMarketById: jest.fn().mockImplementation((id: string) =>
+        Promise.resolve([MARKET_OPEN, MARKET_RESOLVED].find(m => m.market_id === id) ?? null),
+      ),
+      findBetsByAddress: jest.fn().mockResolvedValue([]),
+    });
+  });
+
+  // 1 ─────────────────────────────────────────────────────────────────────────
+  it('getMarkets() with no filters returns all markets', async () => {
+    const result = await getMarkets();
+    expect(result.total).toBe(2);
+    expect(result.markets).toHaveLength(2);
+  });
+
+  // 2 ─────────────────────────────────────────────────────────────────────────
+  it('getMarkets() with status filter returns correct subset', async () => {
+    const result = await getMarkets({ status: 'open' });
+    expect(result.total).toBe(1);
+    expect(result.markets[0].status).toBe('open');
+  });
+
+  // 3 ─────────────────────────────────────────────────────────────────────────
+  it('getMarketById() throws AppError 404 for unknown ID', async () => {
+    await expect(getMarketById('unknown')).rejects.toMatchObject({
+      statusCode: 404,
+    });
+    await expect(getMarketById('unknown')).rejects.toBeInstanceOf(AppError);
+  });
+
+  // 4 ─────────────────────────────────────────────────────────────────────────
+  it('getMarketOdds() returns (0,0,0) for empty pools', async () => {
+    const odds = await getMarketOdds('mkt-1'); // pool totals are all '0'
+    expect(odds).toEqual({ odds_a: 0, odds_b: 0, odds_draw: 0 });
+  });
+
+  // 5 ─────────────────────────────────────────────────────────────────────────
+  it('getMarketOdds() returns correct basis-point values', async () => {
+    setDbAdapter({
+      findMarkets: jest.fn(),
+      findMarketById: jest.fn().mockResolvedValue(
+        makeMarket({
+          market_id: 'mkt-3',
+          pool_a: '6000',
+          pool_b: '3000',
+          pool_draw: '1000',
+          total_pool: '10000',
+        }),
+      ),
+      findBetsByAddress: jest.fn(),
+    });
+
+    const odds = await getMarketOdds('mkt-3');
+    expect(odds).toEqual({ odds_a: 6000, odds_b: 3000, odds_draw: 1000 });
+  });
+
+  // 6 ─────────────────────────────────────────────────────────────────────────
+  it('getPortfolioByAddress() returns empty portfolio for unknown address', async () => {
+    const portfolio = await getPortfolioByAddress('G_UNKNOWN');
+    expect(portfolio.active_bets).toHaveLength(0);
+    expect(portfolio.past_bets).toHaveLength(0);
+    expect(portfolio.pending_claims).toHaveLength(0);
+    expect(portfolio.total_staked_xlm).toBe(0);
+  });
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,5 +38,17 @@ services:
     ports:
       - '3000:3000'
 
+  postgres-test:
+    image: postgres:15-alpine
+    profiles: [test]
+    environment:
+      POSTGRES_USER: boxmeout
+      POSTGRES_PASSWORD: boxmeout
+      POSTGRES_DB: boxmeout_test
+    ports:
+      - '5433:5432'
+    tmpfs:
+      - /var/lib/postgresql/data
+
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary

Closes #557
Closes #558
Closes #559
Closes #560

---

### #557 — Redis caching layer
- `backend/src/config/redis.ts` — ioredis client via `REDIS_URL` env var (lazy connect)
- `backend/src/services/cache.service.ts` — `cacheGet<T>`, `cacheSet` (EX TTL), `cacheDelete`, `cacheDeletePattern`
- `MarketService` — cache applied to `getMarkets` (TTL 30s) and `getMarketStats` (TTL 60s)

### #558  — Unit tests for MarketService
- Implemented minimal `MarketService` logic with injectable `DbAdapter` for clean mocking
- `tests/services/market.service.test.ts` — 6 cases: no-filter list, status filter, 404 on unknown ID, empty-pool odds (0,0,0), correct basis-point odds, empty portfolio
- All 35 unit tests pass; no real DB or Redis required

### #559  — Integration tests for indexer handlers
- `backend/db/schema.sql` — DDL for `markets`, `bets`, `blockchain_events`, `indexer_checkpoints`
- `docker-compose.yml` — added `postgres-test` service (profile `test`, port 5433, tmpfs)
- `backend/src/config/db.ts` — pg `Pool` via `DATABASE_URL`
- `StellarIndexer.ts` — all handlers implemented; `handleBetPlaced` uses a DB transaction for atomicity; `ON CONFLICT DO NOTHING` for idempotency
- `tests/integration/indexer.test.ts` — 7 cases covering all 6 required scenarios + duplicate-event idempotency; schema applied in `beforeAll`, tables truncated in `beforeEach`

### #560  — Structured logging with Pino
- Replaced Winston with Pino in `backend/src/utils/logger.ts`
- `LOG_LEVEL` env var (default `info`); `pino-pretty` transport in non-production
- `pino-http` request logging middleware added to `index.ts`
- `LOG_LEVEL=info` documented in `.env.example`
- `src/utils/__mocks__/logger.ts` — manual Jest mock so existing `jest.mock()` calls work with Pino's plain object

---

**All 42 tests pass.**