### PR TITLE
feat: Docker Compose stack, OpenAPI spec, and Next.js 14 frontend setup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist ./dist
+EXPOSE 3001
+CMD ["node", "dist/index.js"]

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1,0 +1,464 @@
+openapi: 3.0.3
+info:
+  title: BoxMeOut API
+  version: 0.1.0
+  description: REST API for the BoxMeOut decentralized boxing prediction market.
+
+servers:
+  - url: http://localhost:3001
+    description: Local development
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+    oracleKey:
+      type: apiKey
+      in: header
+      name: X-Oracle-Key
+
+  schemas:
+    Market:
+      type: object
+      properties:
+        id:            { type: integer }
+        market_id:     { type: string }
+        contract_address: { type: string }
+        match_id:      { type: string }
+        fighter_a:     { type: string }
+        fighter_b:     { type: string }
+        weight_class:  { type: string }
+        title_fight:   { type: boolean }
+        venue:         { type: string }
+        scheduled_at:  { type: string, format: date-time }
+        status:
+          type: string
+          enum: [open, locked, resolved, cancelled, disputed]
+        outcome:
+          type: string
+          nullable: true
+          enum: [fighter_a, fighter_b, draw, no_contest]
+        pool_a:        { type: string }
+        pool_b:        { type: string }
+        pool_draw:     { type: string }
+        total_pool:    { type: string }
+        fee_bps:       { type: integer }
+        resolved_at:   { type: string, format: date-time, nullable: true }
+        oracle_used:
+          type: string
+          nullable: true
+          enum: [primary, fallback, admin]
+        created_at:    { type: string, format: date-time }
+        updated_at:    { type: string, format: date-time }
+        ledger_sequence: { type: integer }
+
+    MarketStats:
+      type: object
+      properties:
+        market_id:         { type: string }
+        total_bets:        { type: integer }
+        unique_bettors:    { type: integer }
+        largest_bet_xlm:   { type: number }
+        average_bet_xlm:   { type: number }
+        total_pooled_xlm:  { type: number }
+
+    Bet:
+      type: object
+      properties:
+        id:              { type: integer }
+        market_id:       { type: string }
+        bettor_address:  { type: string }
+        side:
+          type: string
+          enum: [fighter_a, fighter_b, draw]
+        amount:          { type: string }
+        amount_xlm:      { type: number }
+        placed_at:       { type: string, format: date-time }
+        claimed:         { type: boolean }
+        claimed_at:      { type: string, format: date-time, nullable: true }
+        payout:          { type: string, nullable: true }
+        tx_hash:         { type: string }
+        ledger_sequence: { type: integer }
+
+    Portfolio:
+      type: object
+      properties:
+        address:          { type: string }
+        active_bets:
+          type: array
+          items: { $ref: '#/components/schemas/Bet' }
+        past_bets:
+          type: array
+          items: { $ref: '#/components/schemas/Bet' }
+        pending_claims:
+          type: array
+          items: { $ref: '#/components/schemas/Bet' }
+        total_staked_xlm: { type: number }
+        total_won_xlm:    { type: number }
+        total_lost_xlm:   { type: number }
+
+    OracleReport:
+      type: object
+      properties:
+        id:             { type: integer }
+        match_id:       { type: string }
+        oracle_address: { type: string }
+        outcome:        { type: string }
+        reported_at:    { type: string, format: date-time }
+        signature:      { type: string }
+        accepted:       { type: boolean }
+        tx_hash:        { type: string, nullable: true }
+        created_at:     { type: string, format: date-time }
+
+    Error:
+      type: object
+      properties:
+        status:  { type: string, example: error }
+        message: { type: string }
+
+paths:
+  /api/markets:
+    get:
+      summary: List markets
+      operationId: listMarkets
+      tags: [Markets]
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [open, locked, resolved, cancelled, disputed]
+        - name: weight_class
+          in: query
+          schema: { type: string }
+        - name: page
+          in: query
+          schema: { type: integer, default: 1 }
+        - name: limit
+          in: query
+          schema: { type: integer, default: 20 }
+      responses:
+        '200':
+          description: Paginated list of markets
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  markets:
+                    type: array
+                    items: { $ref: '#/components/schemas/Market' }
+                  total: { type: integer }
+                  page:  { type: integer }
+                  limit: { type: integer }
+        '400':
+          description: Invalid query parameters
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/markets/{market_id}:
+    get:
+      summary: Get market by ID
+      operationId: getMarket
+      tags: [Markets]
+      parameters:
+        - name: market_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Market detail with current odds
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Market' }
+        '404':
+          description: Market not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/markets/{market_id}/bets:
+    get:
+      summary: Get bets for a market
+      operationId: getMarketBets
+      tags: [Markets]
+      parameters:
+        - name: market_id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: address
+          in: query
+          description: Filter to a single bettor's Stellar address
+          schema: { type: string }
+      responses:
+        '200':
+          description: List of bets
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Bet' }
+        '404':
+          description: Market not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/markets/{market_id}/stats:
+    get:
+      summary: Get aggregate stats for a market
+      operationId: getMarketStats
+      tags: [Markets]
+      parameters:
+        - name: market_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Market statistics
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/MarketStats' }
+        '404':
+          description: Market not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/bets/{bettor_address}:
+    get:
+      summary: Get all bets by a Stellar address
+      operationId: getBetsByAddress
+      tags: [Bets]
+      parameters:
+        - name: bettor_address
+          in: path
+          required: true
+          description: Stellar public key (G...)
+          schema: { type: string }
+      responses:
+        '200':
+          description: List of bets across all markets
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/Bet' }
+        '400':
+          description: Invalid Stellar address
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/portfolio/{address}:
+    get:
+      summary: Get portfolio summary for a Stellar address
+      operationId: getPortfolio
+      tags: [Bets]
+      parameters:
+        - name: address
+          in: path
+          required: true
+          description: Stellar public key (G...)
+          schema: { type: string }
+      responses:
+        '200':
+          description: Portfolio summary (empty portfolio returned if address has no bets)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Portfolio' }
+        '400':
+          description: Invalid Stellar address
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/oracle/submit:
+    post:
+      summary: Submit a signed oracle fight result
+      operationId: submitOracleResult
+      tags: [Oracle]
+      security:
+        - oracleKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [match_id, outcome, reported_at, signature, oracle_address]
+              properties:
+                match_id:       { type: string }
+                outcome:        { type: string, enum: [fighter_a, fighter_b, draw, no_contest] }
+                reported_at:    { type: string, format: date-time }
+                signature:      { type: string, description: Hex-encoded Ed25519 signature }
+                oracle_address: { type: string, description: Stellar public key of the oracle }
+      responses:
+        '200':
+          description: Report accepted and submitted on-chain
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tx_hash:   { type: string }
+                  report_id: { type: integer }
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: Missing or invalid oracle API key / signature verification failed
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/oracle/reports/{match_id}:
+    get:
+      summary: Get all oracle reports for a fight
+      operationId: getOracleReports
+      tags: [Oracle]
+      parameters:
+        - name: match_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: All oracle reports (accepted and rejected) for the fight
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/OracleReport' }
+
+  /api/admin/dispute/{market_id}:
+    post:
+      summary: Flag a market as disputed
+      operationId: flagDispute
+      tags: [Admin]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: market_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [reason]
+              properties:
+                reason: { type: string }
+      responses:
+        '200':
+          description: Market flagged as disputed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tx_hash: { type: string }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404':
+          description: Market not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/admin/resolve-dispute/{market_id}:
+    post:
+      summary: Resolve a disputed market with admin-verified outcome
+      operationId: resolveDispute
+      tags: [Admin]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: market_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [outcome, totp_code]
+              properties:
+                outcome:   { type: string, enum: [fighter_a, fighter_b, draw, no_contest] }
+                totp_code: { type: string, description: 6-digit TOTP code for 2FA verification }
+      responses:
+        '200':
+          description: Dispute resolved on-chain
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tx_hash: { type: string }
+        '401':
+          description: Unauthorized or invalid TOTP code
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404':
+          description: Market not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /api/admin/cancel/{market_id}:
+    post:
+      summary: Cancel a market (fight postponed or called off)
+      operationId: cancelMarket
+      tags: [Admin]
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: market_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [reason]
+              properties:
+                reason: { type: string }
+      responses:
+        '200':
+          description: Market cancelled on-chain
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tx_hash: { type: string }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404':
+          description: Market not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,26 @@
+version: '3.9'
+
+services:
+  postgres_test:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: boxmeout
+      POSTGRES_PASSWORD: boxmeout
+      POSTGRES_DB: boxmeout_test
+    ports:
+      - '5433:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U boxmeout']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis_test:
+    image: redis:7-alpine
+    ports:
+      - '6380:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,19 +12,31 @@ services:
       - '5432:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U boxmeout']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:7-alpine
     restart: unless-stopped
     ports:
       - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   backend:
     build: ./backend
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     env_file: ./backend/.env
     ports:
       - '3001:3001'

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "next/core-web-vitals",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-explicit-any": "warn"
+  }
+}

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "boxmeout-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev -p 3000",
+    "build": "next build",
+    "start": "next start -p 3000",
+    "lint": "next lint",
+    "format": "prettier --write 'src/**/*.{ts,tsx}'"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "zustand": "^4.5.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@typescript-eslint/eslint-plugin": "^7.13.0",
+    "@typescript-eslint/parser": "^7.13.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.3",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "postcss": "^8.4.38",
+    "prettier": "^3.3.2",
+    "tailwindcss": "^3.4.4",
+    "ts-jest": "^29.1.5",
+    "typescript": "^5.4.5"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,28 +4,24 @@
 // ============================================================
 
 import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
 import { Header } from '../components/layout/Header';
+import './globals.css';
+
+const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
   title: 'BOXMEOUT — Boxing Prediction Market on Stellar',
   description: 'Decentralized boxing prediction market powered by Stellar Soroban smart contracts.',
 };
 
-interface RootLayoutProps {
-  children: React.ReactNode;
-}
-
-/**
- * Root layout applied to every page.
- *
- * Must wrap children with:
- *   - Global CSS / Tailwind base styles
- *   - Zustand store provider (if needed)
- *   - Header component
- *   - Main content area
- *
- * Font: use next/font to load Inter or a boxing-appropriate typeface.
- */
-export default function RootLayout({ children }: RootLayoutProps): JSX.Element {
-  // TODO: implement
+export default function RootLayout({ children }: { children: React.ReactNode }): JSX.Element {
+  return (
+    <html lang="en" className={inter.className}>
+      <body className="bg-gray-950 text-white min-h-screen">
+        <Header />
+        {children}
+      </body>
+    </html>
+  );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,11 +5,6 @@
 
 'use client';
 
-// ============================================================
-// BOXMEOUT — Home Page (/  )
-// Lists all boxing markets with filters and sorting.
-// ============================================================
-
 import { useCallback } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useMarkets } from '../hooks/useMarkets';

--- a/frontend/src/hooks/useMarkets.ts
+++ b/frontend/src/hooks/useMarkets.ts
@@ -9,6 +9,8 @@ import type { Market } from '../types';
 import type { MarketFilters } from '../services/api';
 import { fetchMarkets } from '../services/api';
 
+const POLL_INTERVAL = 30_000;
+
 export interface UseMarketsResult {
   markets: Market[];
   total: number;
@@ -56,7 +58,7 @@ export function useMarkets(filters?: MarketFilters): UseMarketsResult {
     // Set up polling interval every 30 seconds
     const intervalId = setInterval(() => {
       fetchAndUpdate();
-    }, 30_000);
+    }, POLL_INTERVAL);
 
     return () => {
       clearInterval(intervalId);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -22,6 +22,18 @@ export class NetworkError extends Error {
   constructor(message = 'Network error') { super(message); this.name = 'NetworkError'; }
 }
 
+async function apiFetch<T>(path: string): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}${path}`);
+  } catch (e) {
+    throw new NetworkError((e as Error).message);
+  }
+  if (res.status === 404) throw new NotFoundError();
+  if (!res.ok) throw new NetworkError(`Unexpected response: ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
 export interface MarketFilters {
   status?: string;
   weight_class?: string;
@@ -48,28 +60,13 @@ export async function fetchMarkets(
   filters?: MarketFilters,
   pagination?: PaginationParams,
 ): Promise<MarketListResponse> {
-  const url = new URL(`${API_BASE}/api/markets`);
-  
-  if (filters?.status) {
-    url.searchParams.append('status', filters.status);
-  }
-  if (filters?.weight_class) {
-    url.searchParams.append('weight_class', filters.weight_class);
-  }
-  if (pagination?.page) {
-    url.searchParams.append('page', pagination.page.toString());
-  }
-  if (pagination?.limit) {
-    url.searchParams.append('limit', pagination.limit.toString());
-  }
-
-  try {
-    const res = await fetch(url.toString());
-    if (!res.ok) throw new NetworkError(`Unexpected response: ${res.status}`);
-    return res.json();
-  } catch (e) {
-    throw new NetworkError((e as Error).message);
-  }
+  const params = new URLSearchParams();
+  if (filters?.status) params.set('status', filters.status);
+  if (filters?.weight_class) params.set('weight_class', filters.weight_class);
+  if (pagination?.page) params.set('page', pagination.page.toString());
+  if (pagination?.limit) params.set('limit', pagination.limit.toString());
+  const qs = params.toString();
+  return apiFetch<MarketListResponse>(`/api/markets${qs ? `?${qs}` : ''}`);
 }
 
 /**
@@ -78,15 +75,7 @@ export async function fetchMarkets(
  * Throws NotFoundError on 404.
  */
 export async function fetchMarketById(market_id: string): Promise<Market> {
-  let res: Response;
-  try {
-    res = await fetch(`${API_BASE}/api/markets/${market_id}`);
-  } catch (e) {
-    throw new NetworkError((e as Error).message);
-  }
-  if (res.status === 404) throw new NotFoundError(`Market ${market_id} not found`);
-  if (!res.ok) throw new NetworkError(`Unexpected response: ${res.status}`);
-  return res.json() as Promise<Market>;
+  return apiFetch<Market>(`/api/markets/${market_id}`);
 }
 
 /**
@@ -94,14 +83,7 @@ export async function fetchMarketById(market_id: string): Promise<Market> {
  * Returns all bets for the market.
  */
 export async function fetchBetsByMarket(market_id: string): Promise<Bet[]> {
-  let res: Response;
-  try {
-    res = await fetch(`${API_BASE}/api/markets/${market_id}/bets`);
-  } catch (e) {
-    throw new NetworkError((e as Error).message);
-  }
-  if (!res.ok) throw new NetworkError(`Unexpected response: ${res.status}`);
-  return res.json();
+  return apiFetch<Bet[]>(`/api/markets/${market_id}/bets`);
 }
 
 /**
@@ -109,17 +91,13 @@ export async function fetchBetsByMarket(market_id: string): Promise<Bet[]> {
  * Returns the full Portfolio object.
  */
 export async function fetchPortfolio(address: string): Promise<Portfolio> {
-  const res = await fetch(`${API_BASE}/api/portfolio/${address}`);
-  if (!res.ok) throw new Error(`fetchPortfolio failed: ${res.status}`);
-  return res.json();
+  return apiFetch<Portfolio>(`/api/portfolio/${address}`);
 }
 
 /**
  * Calls GET /api/markets/:market_id/stats.
  * Returns aggregate MarketStats.
  */
-export async function fetchMarketStats(
-  market_id: string,
-): Promise<MarketStats> {
-  // TODO: implement
+export async function fetchMarketStats(market_id: string): Promise<MarketStats> {
+  return apiFetch<MarketStats>(`/api/markets/${market_id}/stats`);
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: { extend: {} },
+  plugins: [],
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

This PR covers four issues completed in sequence:

---

### Issue #561 — Set up Docker Compose for full local stack
- `docker-compose.yml` includes `postgres`, `redis`, `backend`, and `frontend` services
- `backend/Dockerfile` multi-stage build: compiles TypeScript, runs `dist/index.js`
- Health checks on `postgres` (pg_isready) and `redis` (redis-cli ping)
- `backend` service depends on `postgres` and `redis` with `condition: service_healthy`
- `docker-compose.test.yml` provides isolated `postgres_test` (port 5433) and `redis_test` (port 6380) for integration tests

---

### Issue #562 — Write OpenAPI spec for all endpoints
- `backend/openapi.yaml` documents all 11 REST endpoints:
  - `GET /api/markets`
  - `GET /api/markets/:market_id`
  - `GET /api/markets/:market_id/bets`
  - `GET /api/markets/:market_id/stats`
  - `GET /api/bets/:bettor_address`
  - `GET /api/portfolio/:address`
  - `POST /api/oracle/submit`
  - `GET /api/oracle/reports/:match_id`
  - `POST /api/admin/dispute/:market_id`
  - `POST /api/admin/resolve-dispute/:market_id`
  - `POST /api/admin/cancel/:market_id`
- Each endpoint includes: method, path, auth requirement, query params, request body, response schema, and error codes
- Schemas defined: `Market`, `Bet`, `Portfolio`, `MarketStats`, `OracleReport`, `Error`
- Security schemes: `bearerAuth` (JWT) for admin routes, `oracleKey` (API key header) for oracle routes

---

### Issue #563 — Frontend refactor
- Refactored `frontend/src/services/api.ts` with typed helpers
- Deduplicated `page.tsx` and extracted `useMarkets` constant

---

### Issue #564 — Set up Next.js 14 project with TypeScript
- App Router, `src/` directory, Tailwind CSS, TypeScript
- `tsconfig.json` with `strict: true` and path alias `@/* → ./src/*`
- ESLint with `@typescript-eslint/recommended` rules + Prettier
- `npm run build`, `npm run lint`, and `npm run dev` all pass

---

Closes #561, Closes #562, Closes #563, Closes #564