### PR TITLE
feat(stellar): implement invokeContract() — Issue #30

### DIFF
--- a/backend/src/services/StellarService.ts
+++ b/backend/src/services/StellarService.ts
@@ -4,7 +4,59 @@
 // Contributors: implement every function marked TODO.
 // ============================================================
 
-import { Account, Keypair, Networks, Operation, Server, SorobanServer, TransactionBuilder, xdr } from '@stellar/stellar-sdk';
+import {
+  Contract,
+  Keypair,
+  Networks,
+  TransactionBuilder,
+  Transaction,
+  xdr,
+  rpc,
+} from '@stellar/stellar-sdk';
+
+const POLL_INTERVAL_MS = 2_000;
+const POLL_TIMEOUT_MS  = 30_000;
+const MAX_RETRIES      = 3;
+const BASE_FEE         = 100;
+const FEE_BUMP_FACTOR  = 1.5;
+
+export class StellarInvocationError extends Error {
+  constructor(
+    message: string,
+    public readonly txHash?: string,
+    public readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = 'StellarInvocationError';
+  }
+}
+
+function getRpcServer(): rpc.Server {
+  const rpcUrl = process.env.STELLAR_RPC_URL;
+  if (!rpcUrl) throw new Error('STELLAR_RPC_URL env var is required');
+  return new rpc.Server(rpcUrl);
+}
+
+function getNetworkPassphrase(): string {
+  return process.env.STELLAR_NETWORK === 'public' ? Networks.PUBLIC : Networks.TESTNET;
+}
+
+/**
+ * Polls rpc.getTransaction() until SUCCESS or FAILED, or until timeout.
+ * Returns the final status response, or null on timeout.
+ */
+async function pollTransaction(
+  server: rpc.Server,
+  hash: string,
+): Promise<rpc.Api.GetTransactionResponse | null> {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const result = await server.getTransaction(hash);
+    if (result.status !== rpc.Api.GetTransactionStatus.NOT_FOUND) return result;
+    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+  return null;
+}
 
 /**
  * Builds, simulates, signs, and submits a Soroban contract invocation.
@@ -28,39 +80,77 @@ export async function invokeContract(
   args: xdr.ScVal[],
   source_keypair: Keypair,
 ): Promise<string> {
-  const horizonUrl = process.env.HORIZON_URL ?? 'https://horizon-testnet.stellar.org';
-  const networkPassphrase = process.env.STELLAR_NETWORK === 'public'
-    ? Networks.PUBLIC
-    : Networks.TESTNET;
+  const server = getRpcServer();
+  const networkPassphrase = getNetworkPassphrase();
+  const contract = new Contract(contract_address);
 
-  const server = new Server(horizonUrl);
-  const sourceAccount = await server.loadAccount(source_keypair.publicKey());
+  let fee = BASE_FEE;
 
-  const invokeContractHostFunction = xdr.HostFunction.hostFunctionTypeInvokeContractHostFunction(
-    new xdr.InvokeContractHostFunction({
-      contractAddress: xdr.SorobanAddress.fromAddress(contract_address),
-      functionName: xdr.ScSymbol.fromString(method),
-      args,
-      auth: [],
-    }),
-  );
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    // 1. Load fresh account (fresh sequence number on each retry)
+    const sourceAccount = await server.getAccount(source_keypair.publicKey());
 
-  const transaction = new TransactionBuilder(sourceAccount, {
-    fee: 100,
-    networkPassphrase,
-  })
-    .addOperation(Operation.invokeHostFunction({ function: invokeContractHostFunction, auth: [] }))
-    .setTimeout(30)
-    .build();
+    // 2. Build transaction with invokeHostFunction operation
+    const builtTx = new TransactionBuilder(sourceAccount, { fee: String(fee), networkPassphrase })
+      .addOperation(contract.call(method, ...args))
+      .setTimeout(30)
+      .build();
 
-  transaction.sign(source_keypair);
+    // 3. Simulate to get resource fees + footprint
+    const simResult = await server.simulateTransaction(builtTx);
+    if (rpc.Api.isSimulationError(simResult)) {
+      throw new StellarInvocationError(`Simulation failed: ${simResult.error}`);
+    }
 
-  try {
-    const response = await server.submitTransaction(transaction);
-    return response.hash;
-  } catch (error: any) {
-    throw new Error(`Contract invocation failed: ${error?.response?.data ?? error?.message ?? error}`);
+    // 4. Assemble: applies resource footprint + sets fee = base_fee + resource_fee
+    const resourceFee = parseInt((simResult as rpc.Api.SimulateTransactionSuccessResponse).minResourceFee, 10);
+    fee = Math.ceil((fee + resourceFee) * (attempt > 0 ? FEE_BUMP_FACTOR : 1));
+
+    const preparedTx = rpc.assembleTransaction(builtTx, simResult)
+      .setNetworkPassphrase(networkPassphrase)
+      .build() as Transaction;
+
+    // 5. Sign
+    preparedTx.sign(source_keypair);
+
+    // 6. Submit
+    const sendResult = await server.sendTransaction(preparedTx);
+    if (sendResult.status === 'ERROR') {
+      throw new StellarInvocationError(
+        `sendTransaction rejected: ${sendResult.hash}`,
+        sendResult.hash,
+        sendResult.errorResult,
+      );
+    }
+
+    const hash = sendResult.hash;
+
+    // 7. Poll until SUCCESS / FAILED / timeout
+    const txResult = await pollTransaction(server, hash);
+
+    if (txResult === null) {
+      // TIMEOUT — retry with bumped fee (fee already bumped above for next iteration)
+      if (attempt === MAX_RETRIES) {
+        throw new StellarInvocationError(
+          `Transaction timed out after ${MAX_RETRIES} retries`,
+          hash,
+        );
+      }
+      continue;
+    }
+
+    if (txResult.status === rpc.Api.GetTransactionStatus.SUCCESS) return hash;
+
+    // FAILED
+    throw new StellarInvocationError(
+      `Transaction failed on-chain`,
+      hash,
+      txResult,
+    );
   }
+
+  // Should be unreachable
+  throw new StellarInvocationError('Max retries exceeded');
 }
 
 /**
@@ -80,51 +170,34 @@ export async function readContractState<T>(
   method: string,
   args: xdr.ScVal[],
 ): Promise<T> {
-  const rpcUrl = process.env.STELLAR_RPC_URL;
-  if (!rpcUrl) throw new Error('STELLAR_RPC_URL env var is required');
+  const server = getRpcServer();
+  const networkPassphrase = getNetworkPassphrase();
+  const contract = new Contract(contract_address);
 
-  const networkPassphrase = process.env.STELLAR_NETWORK === 'public'
-    ? Networks.PUBLIC
-    : Networks.TESTNET;
+  // Use a random ephemeral account — simulation doesn't need a real sequence number
+  const ephemeral = Keypair.random();
+  const sourceAccount = await server.getAccount(ephemeral.publicKey()).catch(() => {
+    // Fallback: build a dummy account object for simulation
+    const { Account } = require('@stellar/stellar-sdk');
+    return new Account(ephemeral.publicKey(), '0');
+  });
 
-  const sorobanServer = new SorobanServer(rpcUrl);
-  const sourceAccount = new Account(Keypair.random().publicKey(), '0');
-
-  const invokeContractHostFunction = xdr.HostFunction.hostFunctionTypeInvokeContractHostFunction(
-    new xdr.InvokeContractHostFunction({
-      contractAddress: xdr.SorobanAddress.fromAddress(contract_address),
-      functionName: xdr.ScSymbol.fromString(method),
-      args,
-      auth: [],
-    }),
-  );
-
-  const transaction = new TransactionBuilder(sourceAccount, {
-    fee: 100,
-    networkPassphrase,
-  })
-    .addOperation(Operation.invokeHostFunction({ function: invokeContractHostFunction, auth: [] }))
+  const transaction = new TransactionBuilder(sourceAccount, { fee: String(BASE_FEE), networkPassphrase })
+    .addOperation(contract.call(method, ...args))
     .setTimeout(30)
     .build();
 
-  const response = await sorobanServer.simulateTransaction(transaction);
-  if ('error' in response && response.error) {
-    throw new Error(`Simulation error: ${JSON.stringify(response.error)}`);
+  const response = await server.simulateTransaction(transaction);
+  if (rpc.Api.isSimulationError(response)) {
+    throw new Error(`Simulation error: ${response.error}`);
   }
 
-  const result = (response as any).results?.[0];
-  if (!result || result.status !== 'SUCCESS') {
-    throw new Error(
-      `Simulation failed${result?.status ? `: ${result.status}` : ' without a result'}`,
-    );
+  const successResponse = response as rpc.Api.SimulateTransactionSuccessResponse;
+  if (!successResponse.result?.retval) {
+    throw new Error('Simulation returned no retval');
   }
 
-  const returnValue = result.returnValue;
-  if (!returnValue) {
-    throw new Error('Simulation returned no returnValue');
-  }
-
-  return parseScVal(returnValue) as T;
+  return parseScVal(successResponse.result.retval) as T;
 }
 
 /**

--- a/backend/tests/services/StellarService.test.ts
+++ b/backend/tests/services/StellarService.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { Keypair, xdr } from '@stellar/stellar-sdk';
+
+// ── Shared RPC mock state (defined before jest.mock so factory can close over them) ──
+// jest.mock is hoisted, but variables declared with `const` in the module scope
+// are NOT accessible inside the factory. We work around this by using a plain
+// object that is mutated per-test.
+const rpc = {
+  getAccount:          jest.fn<() => Promise<unknown>>(),
+  simulateTransaction: jest.fn<() => Promise<unknown>>(),
+  sendTransaction:     jest.fn<() => Promise<unknown>>(),
+  getTransaction:      jest.fn<() => Promise<unknown>>(),
+};
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const actual = jest.requireActual('@stellar/stellar-sdk') as Record<string, unknown>;
+
+  const mockTx = { sign: jest.fn() };
+  const mockBuilder = {
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue(mockTx),
+  };
+  const mockAssembled = {
+    setNetworkPassphrase: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue(mockTx),
+  };
+
+  return {
+    ...actual,
+    Contract: jest.fn().mockImplementation(() => ({
+      call: jest.fn().mockReturnValue('op'),
+    })),
+    TransactionBuilder: jest.fn().mockImplementation(() => mockBuilder),
+    rpc: {
+      // Server constructor returns the shared `rpc` object from outer scope.
+      // Because jest.mock is hoisted, we can't reference `rpc` directly here —
+      // instead we use a getter trick via a module-level variable accessed at
+      // call time (not at factory-definition time).
+      Server: jest.fn().mockImplementation(() => ({
+        getAccount: (...a: unknown[]) => (global as any).__rpcMock.getAccount(...a),
+        simulateTransaction: (...a: unknown[]) => (global as any).__rpcMock.simulateTransaction(...a),
+        sendTransaction: (...a: unknown[]) => (global as any).__rpcMock.sendTransaction(...a),
+        getTransaction: (...a: unknown[]) => (global as any).__rpcMock.getTransaction(...a),
+      })),
+      assembleTransaction: jest.fn().mockReturnValue(mockAssembled),
+      Api: {
+        GetTransactionStatus: { SUCCESS: 'SUCCESS', FAILED: 'FAILED', NOT_FOUND: 'NOT_FOUND' },
+        isSimulationError: (r: unknown) => !!(r as Record<string, unknown>).error,
+        isSimulationSuccess: (r: unknown) => !(r as Record<string, unknown>).error,
+      },
+    },
+  };
+});
+
+// Expose the shared mock object on global so the factory can reach it at call time
+(global as any).__rpcMock = rpc;
+
+import { invokeContract, StellarInvocationError } from '../../src/services/StellarService';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const CONTRACT = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM';
+const METHOD   = 'place_bet';
+const ARGS: xdr.ScVal[] = [];
+const KEYPAIR  = Keypair.random();
+const TX_HASH  = 'abc123hash';
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('invokeContract()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.STELLAR_RPC_URL = 'https://soroban-testnet.stellar.org';
+    process.env.STELLAR_NETWORK = 'testnet';
+
+    rpc.getAccount.mockResolvedValue({ id: KEYPAIR.publicKey(), sequence: '0' });
+    rpc.simulateTransaction.mockResolvedValue({ minResourceFee: '500', result: { retval: {} } });
+    rpc.sendTransaction.mockResolvedValue({ status: 'PENDING', hash: TX_HASH });
+    rpc.getTransaction.mockResolvedValue({ status: 'SUCCESS' });
+  });
+
+  // ── AC1: Successful invocation returns tx hash ──────────────────────────
+
+  it('returns the tx hash on SUCCESS', async () => {
+    const hash = await invokeContract(CONTRACT, METHOD, ARGS, KEYPAIR);
+    expect(hash).toBe(TX_HASH);
+  });
+
+  it('calls simulate, send, and getTransaction in order', async () => {
+    await invokeContract(CONTRACT, METHOD, ARGS, KEYPAIR);
+    expect(rpc.simulateTransaction).toHaveBeenCalledTimes(1);
+    expect(rpc.sendTransaction).toHaveBeenCalledTimes(1);
+    expect(rpc.getTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws StellarInvocationError when simulation returns an error', async () => {
+    rpc.simulateTransaction.mockResolvedValue({ error: 'sim failed' });
+    await expect(invokeContract(CONTRACT, METHOD, ARGS, KEYPAIR))
+      .rejects.toBeInstanceOf(StellarInvocationError);
+  });
+
+  it('throws StellarInvocationError when sendTransaction returns ERROR status', async () => {
+    rpc.sendTransaction.mockResolvedValue({ status: 'ERROR', hash: TX_HASH, errorResult: {} });
+    await expect(invokeContract(CONTRACT, METHOD, ARGS, KEYPAIR))
+      .rejects.toBeInstanceOf(StellarInvocationError);
+  });
+
+  // ── AC2: FAILED on-chain throws StellarInvocationError ─────────────────
+
+  it('throws StellarInvocationError with txHash when getTransaction returns FAILED', async () => {
+    rpc.getTransaction.mockResolvedValue({ status: 'FAILED' });
+    const err = await invokeContract(CONTRACT, METHOD, ARGS, KEYPAIR).catch(e => e);
+    expect(err).toBeInstanceOf(StellarInvocationError);
+    expect(err.txHash).toBe(TX_HASH);
+  });
+
+  // ── AC2: Fee-too-low / timeout triggers retry ───────────────────────────
+
+  it('retries on timeout and succeeds on second attempt', async () => {
+    // Strategy: make Date.now() return a value past the deadline on the SECOND call
+    // (first call sets deadline, second call is the while-check → exits immediately)
+    const base = Date.now();
+    let nowCalls = 0;
+    jest.spyOn(Date, 'now').mockImplementation(() => {
+      nowCalls++;
+      // Call 1: sets deadline = base + 30_000
+      // Call 2+: return base + 31_000 → while(Date.now() < deadline) is false → timeout
+      // After restoreAllMocks on retry, real Date.now is used
+      return nowCalls === 1 ? base : base + 31_000;
+    });
+
+    rpc.sendTransaction
+      .mockResolvedValueOnce({ status: 'PENDING', hash: 'hash-1' })
+      .mockResolvedValueOnce({ status: 'PENDING', hash: TX_HASH });
+
+    rpc.getTransaction.mockResolvedValue({ status: 'SUCCESS' });
+
+    const hash = await invokeContract(CONTRACT, METHOD, ARGS, KEYPAIR);
+    expect(hash).toBe(TX_HASH);
+    expect(rpc.sendTransaction).toHaveBeenCalledTimes(2);
+
+    jest.restoreAllMocks();
+  });
+
+  // ── AC3: Max retries exceeded throws error ──────────────────────────────
+
+  it('throws StellarInvocationError after max retries exceeded', async () => {
+    // Make every poll timeout immediately: odd calls set deadline, even calls exceed it
+    let nowCalls = 0;
+    const base = Date.now();
+    jest.spyOn(Date, 'now').mockImplementation(() => {
+      nowCalls++;
+      return nowCalls % 2 === 1 ? base : base + 31_000;
+    });
+
+    rpc.getTransaction.mockResolvedValue({ status: 'NOT_FOUND' });
+    rpc.sendTransaction.mockResolvedValue({ status: 'PENDING', hash: TX_HASH });
+
+    const err = await invokeContract(CONTRACT, METHOD, ARGS, KEYPAIR).catch(e => e);
+    expect(err).toBeInstanceOf(StellarInvocationError);
+    expect(err.message).toMatch(/retries/i);
+    expect(rpc.sendTransaction).toHaveBeenCalledTimes(4);
+
+    jest.restoreAllMocks();
+  });
+
+  it('throws if STELLAR_RPC_URL is not set', async () => {
+    delete process.env.STELLAR_RPC_URL;
+    await expect(invokeContract(CONTRACT, METHOD, ARGS, KEYPAIR))
+      .rejects.toThrow('STELLAR_RPC_URL');
+  });
+});


### PR DESCRIPTION
## Summary

Implements `invokeContract()` in `backend/src/services/StellarService.ts` per Issue #30.

## Changes

**`StellarService.ts`**
- Added `StellarInvocationError` class (carries `txHash` and `details`)
- Replaced stub `invokeContract()` with full implementation using `@stellar/stellar-sdk` v15 `rpc` namespace:
  - Loads fresh account sequence via `rpc.Server.getAccount()`
  - Builds transaction with `Contract.call()` + `TransactionBuilder`
  - Simulates via `rpc.Server.simulateTransaction()` to get resource fees
  - Assembles with `rpc.assembleTransaction()` (applies footprint + fee)
  - Signs and submits via `rpc.Server.sendTransaction()`
  - Polls `rpc.Server.getTransaction()` every 2 s up to 30 s
  - On timeout: bumps fee ×1.5 and retries up to 3 times
  - Returns tx hash on SUCCESS; throws `StellarInvocationError` on FAILED or max retries
- Updated `readContractState()` to use same `rpc.Server` + `Contract.call()` pattern

**`tests/services/StellarService.test.ts`** (new)
- 8 unit tests covering all acceptance criteria: success path, call order, simulation error, sendTransaction ERROR, FAILED on-chain, retry on timeout, max retries exceeded, missing env var

## Tested

All 8 tests pass (`npm test`).

Closes #552 