### PR TITLE
fix(contracts): replace all unwrap()/expect() with typed ContractErro…

### DIFF
--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -64,8 +64,8 @@ impl Market {
         Ok(())
     }
 
-    fn load_state(env: &Env) -> MarketState {
-        env.storage().persistent().get(&STATE).unwrap()
+    fn load_state(env: &Env) -> Result<MarketState, ContractError> {
+        env.storage().persistent().get(&STATE).ok_or(ContractError::MarketNotFound)
     }
 
     fn save_state(env: &Env, state: &MarketState) {
@@ -85,11 +85,14 @@ impl Market {
         env.storage().persistent().set(&BETS, &map);
     }
 
-    fn is_oracle_whitelisted(env: &Env, caller: &Address) -> bool {
-        let factory: Address = env.storage().persistent().get(&FACTORY).unwrap();
+    fn is_oracle_whitelisted(env: &Env, caller: &Address) -> Result<bool, ContractError> {
+        let factory: Address = env
+            .storage().persistent()
+            .get(&FACTORY)
+            .ok_or(ContractError::NotFactory)?;
         let client = FactoryClient::new(env, &factory);
         let oracles = client.get_oracles();
-        oracles.contains(caller.clone())
+        Ok(oracles.contains(caller.clone()))
     }
 }
 
@@ -160,7 +163,7 @@ impl Market {
         bettor.require_auth();                          // auth first
         Self::require_not_paused(&env)?;                // pause guard
 
-        let state = Self::load_state(&env);
+        let state = Self::load_state(&env)?;
 
         if state.status != MarketStatus::Open {
             return Err(ContractError::InvalidMarketStatus);
@@ -227,11 +230,11 @@ impl Market {
         caller.require_auth();
         Self::require_not_paused(&env)?;
 
-        if !Self::is_oracle_whitelisted(&env, &caller) {
+        if !Self::is_oracle_whitelisted(&env, &caller)? {
             return Err(ContractError::OracleNotWhitelisted);
         }
 
-        let mut state = Self::load_state(&env);
+        let mut state = Self::load_state(&env)?;
         if state.status != MarketStatus::Open {
             return Err(ContractError::InvalidMarketStatus);
         }
@@ -262,11 +265,11 @@ impl Market {
         oracle.require_auth();
         Self::require_not_paused(&env)?;
 
-        if !Self::is_oracle_whitelisted(&env, &oracle) {
+        if !Self::is_oracle_whitelisted(&env, &oracle)? {
             return Err(ContractError::OracleNotWhitelisted);
         }
 
-        let mut state = Self::load_state(&env);
+        let mut state = Self::load_state(&env)?;
         if state.status != MarketStatus::Locked {
             return Err(ContractError::InvalidMarketStatus);
         }
@@ -350,7 +353,7 @@ impl Market {
         Self::require_not_claiming(&env)?;              // reentrancy guard
 
         // Reload state fresh from storage (never use a stale copy)
-        let state = Self::load_state(&env);
+        let state = Self::load_state(&env)?;
 
         if state.status != MarketStatus::Resolved {
             return Err(ContractError::InvalidMarketStatus);
@@ -421,7 +424,10 @@ impl Market {
 
         // ── INTERACTIONS ──────────────────────────────────────────────────────
         let token_client = token::Client::new(&env, &token);
-        let treasury: Address = env.storage().persistent().get(&TREASURY).unwrap();
+        let treasury: Address = env
+            .storage().persistent()
+            .get(&TREASURY)
+            .ok_or(ContractError::Unauthorized)?;
 
         // Transfer fee to treasury first
         if fee > 0 {
@@ -457,7 +463,7 @@ impl Market {
         Self::require_not_claiming(&env)?;
 
         // Reload state fresh from storage
-        let state = Self::load_state(&env);
+        let state = Self::load_state(&env)?;
 
         if state.status != MarketStatus::Cancelled {
             return Err(ContractError::InvalidMarketStatus);
@@ -516,11 +522,11 @@ impl Market {
         caller.require_auth();
         Self::require_not_paused(&env)?;
 
-        if !Self::is_oracle_whitelisted(&env, &caller) {
+        if !Self::is_oracle_whitelisted(&env, &caller)? {
             return Err(ContractError::Unauthorized);
         }
 
-        let mut state = Self::load_state(&env);
+        let mut state = Self::load_state(&env)?;
         if state.status != MarketStatus::Open && state.status != MarketStatus::Locked {
             return Err(ContractError::InvalidMarketStatus);
         }
@@ -544,12 +550,15 @@ impl Market {
         Self::require_not_paused(&env)?;
 
         // Admin must be the factory address (factory is the privileged admin)
-        let factory: Address = env.storage().persistent().get(&FACTORY).unwrap();
+        let factory: Address = env
+            .storage().persistent()
+            .get(&FACTORY)
+            .ok_or(ContractError::NotFactory)?;
         if admin != factory {
             return Err(ContractError::Unauthorized);
         }
 
-        let mut state = Self::load_state(&env);
+        let mut state = Self::load_state(&env)?;
         if state.status != MarketStatus::Resolved {
             return Err(ContractError::InvalidMarketStatus);
         }
@@ -572,12 +581,15 @@ impl Market {
         admin.require_auth();
         Self::require_not_paused(&env)?;
 
-        let factory: Address = env.storage().persistent().get(&FACTORY).unwrap();
+        let factory: Address = env
+            .storage().persistent()
+            .get(&FACTORY)
+            .ok_or(ContractError::NotFactory)?;
         if admin != factory {
             return Err(ContractError::Unauthorized);
         }
 
-        let mut state = Self::load_state(&env);
+        let mut state = Self::load_state(&env)?;
         if state.status != MarketStatus::Disputed {
             return Err(ContractError::InvalidMarketStatus);
         }
@@ -595,7 +607,7 @@ impl Market {
     // READ-ONLY FUNCTIONS
     // =========================================================================
 
-    pub fn get_state(env: Env) -> MarketState {
+    pub fn get_state(env: Env) -> Result<MarketState, ContractError> {
         Self::load_state(&env)
     }
 
@@ -604,7 +616,10 @@ impl Market {
     }
 
     pub fn get_current_odds(env: Env) -> (u32, u32, u32) {
-        let state = Self::load_state(&env);
+        let state = match Self::load_state(&env) {
+            Ok(s) => s,
+            Err(_) => return (0, 0, 0),
+        };
         if state.total_pool == 0 {
             return (0, 0, 0);
         }
@@ -615,7 +630,10 @@ impl Market {
     }
 
     pub fn estimate_payout(env: Env, side: BetSide, amount: i128) -> i128 {
-        let state = Self::load_state(&env);
+        let state = match Self::load_state(&env) {
+            Ok(s) => s,
+            Err(_) => return 0,
+        };
         if state.status != MarketStatus::Open {
             return 0;
         }
@@ -645,7 +663,10 @@ impl Market {
     }
 
     pub fn get_pool_sizes(env: Env) -> (i128, i128, i128) {
-        let state = Self::load_state(&env);
+        let state = match Self::load_state(&env) {
+            Ok(s) => s,
+            Err(_) => return (0, 0, 0),
+        };
         (state.pool_a, state.pool_b, state.pool_draw)
     }
 
@@ -718,7 +739,10 @@ impl Market {
     /// Only callable by the factory (admin).
     pub fn emergency_pause(env: Env, admin: Address) -> Result<(), ContractError> {
         admin.require_auth();
-        let factory: Address = env.storage().persistent().get(&FACTORY).unwrap();
+        let factory: Address = env
+            .storage().persistent()
+            .get(&FACTORY)
+            .ok_or(ContractError::NotFactory)?;
         if admin != factory {
             return Err(ContractError::Unauthorized);
         }
@@ -729,7 +753,10 @@ impl Market {
     /// Lifts the emergency pause.
     pub fn emergency_unpause(env: Env, admin: Address) -> Result<(), ContractError> {
         admin.require_auth();
-        let factory: Address = env.storage().persistent().get(&FACTORY).unwrap();
+        let factory: Address = env
+            .storage().persistent()
+            .get(&FACTORY)
+            .ok_or(ContractError::NotFactory)?;
         if admin != factory {
             return Err(ContractError::Unauthorized);
         }

--- a/contracts/market_factory/src/lib.rs
+++ b/contracts/market_factory/src/lib.rs
@@ -20,7 +20,7 @@ const DEFAULT_CONFIG: &str  = "DEFAULT_CONFIG";
 #[contractclient(name = "MarketClient")]
 pub trait MarketInterface {
     fn get_bets_by_address(env: Env, bettor: Address) -> Vec<BetRecord>;
-    fn get_state(env: Env) -> MarketState;
+    fn get_state(env: Env) -> Result<MarketState, ContractError>;
 }
 
 #[contract]
@@ -28,7 +28,10 @@ pub struct MarketFactory;
 
 impl MarketFactory {
     fn require_admin(env: &Env, caller: &Address) -> Result<(), ContractError> {
-        let admin: Address = env.storage().persistent().get(&ADMIN).unwrap();
+        let admin: Address = env
+            .storage().persistent()
+            .get(&ADMIN)
+            .ok_or(ContractError::Unauthorized)?;
         if *caller != admin {
             return Err(ContractError::Unauthorized);
         }
@@ -135,8 +138,9 @@ impl MarketFactory {
         while i < count && fetched < cap {
             if let Some(addr) = map.get(i) {
                 let client = MarketClient::new(&env, &addr);
-                let state = client.get_state();
-                result.push_back((i, state.status));
+                if let Ok(state) = client.get_state() {
+                    result.push_back((i, state.status));
+                }
             }
             i += 1;
             fetched += 1;
@@ -195,7 +199,10 @@ impl MarketFactory {
         current_admin.require_auth();
         Self::require_admin(&env, &current_admin)?;
 
-        let old_admin: Address = env.storage().persistent().get(&ADMIN).unwrap();
+        let old_admin: Address = env
+            .storage().persistent()
+            .get(&ADMIN)
+            .ok_or(ContractError::Unauthorized)?;
         env.storage().persistent().set(&ADMIN, &new_admin);
         boxmeout_shared::emit_admin_transferred(&env, old_admin, new_admin);
         Ok(())

--- a/contracts/treasury/src/lib.rs
+++ b/contracts/treasury/src/lib.rs
@@ -20,7 +20,10 @@ pub struct Treasury;
 
 impl Treasury {
     fn require_admin(env: &Env, caller: &Address) -> Result<(), ContractError> {
-        let admin: Address = env.storage().persistent().get(&ADMIN).unwrap();
+        let admin: Address = env
+            .storage().persistent()
+            .get(&ADMIN)
+            .ok_or(ContractError::Unauthorized)?;
         if *caller != admin {
             return Err(ContractError::Unauthorized);
         }


### PR DESCRIPTION
Summary
  
  Eliminates every unwrap() and expect() call from non-test contract code. All
  error paths now return a typed ContractError variant via ? or explicit
  Err(...). No panics possible in contract execution paths.
  
  Changes
  
  market/src/lib.rs
  
  - load_state → returns Result<MarketState, ContractError>
   (.ok_or(MarketNotFound))
  - is_oracle_whitelisted → returns Result<bool, ContractError>
   (.ok_or(NotFactory))
  - All callers propagate with ?
  - FACTORY / TREASURY storage reads use .ok_or(NotFactory / Unauthorized)
  - get_state return type changed to Result<MarketState, ContractError>
  - Read-only views (get_current_odds, estimate_payout, get_pool_sizes) use match
   on load_state and return safe defaults on error
  
  market_factory/src/lib.rs
  
  - require_admin / transfer_admin — ADMIN storage read uses .ok_or(Unauthorized)
  - MarketInterface::get_state trait signature updated to match new return type
  - list_markets uses if let Ok(state) to skip uninitialized markets gracefully
  
  treasury/src/lib.rs
  
  - require_admin — ADMIN storage read uses .ok_or(Unauthorized)
  
  shared/src/errors.rs — no changes; #[contracterror] and all variants were
  already in place.
  
  Acceptance Criteria
  
  - [x] Zero unwrap() calls in non-test contract code
  - [x] All error paths return a typed ContractError variant
  - [x] No new error variants added — all variants were already reachable
  
  Testing
  
  Existing test suite in market/src/tests.rs is unaffected (tests do not call
  get_state directly and unwrap() in test code is permitted).
  
  Closes #509 