### PR TITLE
feat: implement useMarkets hook with 30s polling and refetch timer reset

### DIFF
--- a/frontend/src/hooks/useMarkets.ts
+++ b/frontend/src/hooks/useMarkets.ts
@@ -33,6 +33,7 @@ export function useMarkets(filters?: MarketFilters): UseMarketsResult {
   const [total, setTotal] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const [tick, setTick] = useState(0);
 
   const fetchAndUpdate = useCallback(async () => {
     try {
@@ -40,30 +41,23 @@ export function useMarkets(filters?: MarketFilters): UseMarketsResult {
       setMarkets(response.markets);
       setTotal(response.total);
       setError(null);
-      setIsLoading(false);
     } catch (e) {
       setError(e as Error);
+    } finally {
       setIsLoading(false);
     }
   }, [filters]);
 
+  // Reset interval and trigger immediate fetch
   const refetch = useCallback(() => {
-    fetchAndUpdate();
-  }, [fetchAndUpdate]);
+    setTick((t) => t + 1);
+  }, []);
 
   useEffect(() => {
-    // Initial fetch
     fetchAndUpdate();
-
-    // Set up polling interval every 30 seconds
-    const intervalId = setInterval(() => {
-      fetchAndUpdate();
-    }, POLL_INTERVAL);
-
-    return () => {
-      clearInterval(intervalId);
-    };
-  }, [fetchAndUpdate]);
+    const id = setInterval(fetchAndUpdate, POLL_INTERVAL);
+    return () => clearInterval(id);
+  }, [fetchAndUpdate, tick]);
 
   return { markets, total, isLoading, error, refetch };
 }


### PR DESCRIPTION
## Closes

Closes #

## What this PR does

<!-- One paragraph. What did you implement? Do not explain how — the code does that. -->

## Testing

<!-- How did you verify this works? What test cases did you add? -->

## Screenshots (frontend changes only)

<!-- Add before/after screenshots or a short screen recording. -->

## Checklist

- [ ] I have read `docs/contributing.md`
- [ ] My code follows the naming conventions in the guidelines
- [ ] I have added or updated tests for my changes
- [ ] All tests pass locally (`cargo test` / `npm test`)
- [ ] Lint passes (`cargo clippy` / `npm run lint`)
- [ ] No `console.log` or `unwrap()` left in production paths
- [ ] No secrets committed

closes #570 