### PR TITLE
feat: add SEO metadata to all pages using Next.js Metadata API

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -11,7 +11,10 @@ import './globals.css';
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: 'BOXMEOUT — Boxing Prediction Market on Stellar',
+  title: {
+    default: 'BoxMeOut — Boxing Prediction Markets',
+    template: '%s | BoxMeOut',
+  },
   description: 'Decentralized boxing prediction market powered by Stellar Soroban smart contracts.',
 };
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -13,7 +13,7 @@ const inter = Inter({ subsets: ['latin'] });
 export const metadata: Metadata = {
   title: {
     default: 'BoxMeOut — Boxing Prediction Markets',
-    template: '%s | BoxMeOut',
+    template: '%s — BoxMeOut',
   },
   description: 'Decentralized boxing prediction market powered by Stellar Soroban smart contracts.',
 };

--- a/frontend/src/app/markets/[market_id]/page.tsx
+++ b/frontend/src/app/markets/[market_id]/page.tsx
@@ -2,8 +2,20 @@
 // BOXMEOUT — Market Detail Page (/markets/[market_id])
 // ============================================================
 
+import { Metadata } from 'next';
 import { ErrorBoundary } from '../../../components/ui/ErrorBoundary';
 import MarketDetailContent from './MarketDetailContent';
+
+export async function generateMetadata({ params }: { params: { market_id: string } }): Promise<Metadata> {
+  return {
+    title: `Fight #${params.market_id} — Boxing Prediction`,
+    openGraph: {
+      title: `Fight #${params.market_id} | BoxMeOut`,
+      description: 'Predict the outcome of this boxing match on BoxMeOut.',
+      images: [{ url: '/og-image.png' }],
+    },
+  };
+}
 
 interface MarketDetailPageProps {
   params: { market_id: string };

--- a/frontend/src/app/portfolio/layout.tsx
+++ b/frontend/src/app/portfolio/layout.tsx
@@ -1,0 +1,9 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'My Portfolio',
+};
+
+export default function PortfolioLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "BOXMEOUT_STELLA",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## Closes
Closes #802

## What this PR does
Adds proper `<title>` and `<meta>` tags to all pages using the Next.js Metadata API.

## Testing
- Verified title template renders correctly via Next.js Metadata API
- Portfolio page title resolves to "My Portfolio — BoxMeOut"
- Market detail page generates dynamic title with market ID
- OpenGraph tags added for social sharing on market detail page

## Screenshots (frontend changes only)
N/A — metadata changes are not visible in UI but reflect in browser tab and social previews

## Checklist
- [x] I have read the contribution guidelines
- [x] My changes follow the project code style
- [x] I have tested my changes