### PR TITLE
feat(frontend): build portfolio page, bet history table, countdown ti…

### DIFF
--- a/frontend/src/app/markets/[market_id]/MarketDetailContent.tsx
+++ b/frontend/src/app/markets/[market_id]/MarketDetailContent.tsx
@@ -74,7 +74,7 @@ export default function MarketDetailContent({ market_id }: { market_id: string }
           {market.fighter_a} <span className="text-gray-500">vs</span> {market.fighter_b}
         </h1>
         <p className="text-sm text-gray-400">{market.venue}</p>
-        <CountdownTimer scheduled_at={market.scheduled_at} label="Starts in" />
+        <CountdownTimer targetDate={market.scheduled_at} label="Starts in" />
       </div>
 
       {/* Odds bar + pool sizes */}

--- a/frontend/src/app/portfolio/page.tsx
+++ b/frontend/src/app/portfolio/page.tsx
@@ -2,41 +2,84 @@
 
 // ============================================================
 // BOXMEOUT — Portfolio Page (/portfolio)
-// Shows the connected user's betting history and pending claims.
 // ============================================================
 
-'use client';
-
-import { useState, useEffect } from 'react';
+import { useMemo, useCallback, useState } from 'react';
 import Link from 'next/link';
 import { useWallet } from '../../hooks/useWallet';
 import { usePortfolio } from '../../hooks/usePortfolio';
+import { useMarkets } from '../../hooks/useMarkets';
 import { ConnectPrompt } from '../../components/ui/ConnectPrompt';
 import { BetHistoryTable } from '../../components/bet/BetHistoryTable';
 import { TxStatusToast } from '../../components/ui/TxStatusToast';
+import type { Bet } from '../../types';
+
+// ─── BettorStats ─────────────────────────────────────────────────────────────
+
+interface BettorStatsProps {
+  totalStaked: number;
+  totalWon: number;
+  totalLost: number;
+  pendingClaimsCount: number;
+}
+
+function BettorStats({ totalStaked, totalWon, totalLost, pendingClaimsCount }: BettorStatsProps) {
+  const winRate = totalStaked > 0 ? ((totalWon / totalStaked) * 100).toFixed(1) : '0.0';
+  const stats = [
+    { label: 'Total Staked', value: `${totalStaked.toFixed(2)} XLM` },
+    { label: 'Total Won',    value: `${totalWon.toFixed(2)} XLM`,  color: 'text-green-400' },
+    { label: 'Total Lost',   value: `${totalLost.toFixed(2)} XLM`, color: 'text-red-400' },
+    { label: 'Win Rate',     value: `${winRate}%` },
+    { label: 'Pending Claims', value: String(pendingClaimsCount), color: pendingClaimsCount > 0 ? 'text-amber-400' : undefined },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
+      {stats.map(({ label, value, color }) => (
+        <div key={label} className="bg-gray-900 rounded-xl p-4 text-center">
+          <p className="text-xs text-gray-400">{label}</p>
+          <p className={`text-base font-semibold mt-1 break-words ${color ?? 'text-white'}`}>{value}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── Page ────────────────────────────────────────────────────────────────────
 
 export default function PortfolioPage(): JSX.Element {
   const { isConnected } = useWallet();
   const { portfolio, isLoading, claimTxStatus, claimWinnings, claimRefund } = usePortfolio();
-  const [dismissedError, setDismissedError] = useState(false);
+  const { markets } = useMarkets();
+  const [claimingAll, setClaimingAll] = useState(false);
+  const [dismissedToast, setDismissedToast] = useState(false);
 
-  // Reset dismissedError when status changes from error
-  useEffect(() => {
-    if (dismissedError && claimTxStatus.status !== 'error') {
-      setDismissedError(false);
+  const marketsMap = useMemo(
+    () => Object.fromEntries(markets.map((m) => [m.market_id, m])),
+    [markets],
+  );
+
+  const allBets: Bet[] = useMemo(() => {
+    if (!portfolio) return [];
+    return [
+      ...portfolio.pending_claims,
+      ...portfolio.active_bets,
+      ...portfolio.past_bets,
+    ];
+  }, [portfolio]);
+
+  const handleClaimAll = useCallback(async () => {
+    if (!portfolio || claimingAll) return;
+    setClaimingAll(true);
+    // Deduplicate by market_id — one tx per claimable market
+    const uniqueMarkets = [...new Set(portfolio.pending_claims.map((b) => b.market_id))];
+    for (const market_id of uniqueMarkets) {
+      await claimWinnings(market_id);
     }
-  }, [claimTxStatus.status, dismissedError]);
+    setClaimingAll(false);
+  }, [portfolio, claimWinnings, claimingAll]);
 
-  // Show toast unless it's an error and user dismissed it
-  const displayStatus = dismissedError && claimTxStatus.status === 'error' 
-    ? { hash: null, status: 'idle' as const, error: null }
-    : claimTxStatus;
-
-  const handleDismiss = () => {
-    if (claimTxStatus.status === 'error') {
-      setDismissedError(true);
-    }
-  };
+  const displayStatus = dismissedToast ? { hash: null, status: 'idle' as const, error: null } : claimTxStatus;
 
   if (!isConnected) {
     return (
@@ -50,62 +93,61 @@ export default function PortfolioPage(): JSX.Element {
     return <main className="text-center mt-20 text-gray-400">Loading portfolio…</main>;
   }
 
-  const empty = !portfolio || (
-    portfolio.active_bets.length === 0 &&
-    portfolio.past_bets.length === 0 &&
-    portfolio.pending_claims.length === 0
-  );
+  const isEmpty = !portfolio || allBets.length === 0;
 
-  if (empty) {
+  if (isEmpty) {
     return (
       <main className="text-center mt-20 space-y-3 px-4">
+        <p className="text-4xl">🥊</p>
         <p className="text-gray-400">No bets yet — find a fight to bet on</p>
-        <Link href="/" className="text-amber-400 hover:text-amber-300 text-sm">Browse markets →</Link>
+        <Link href="/" className="inline-block text-amber-400 hover:text-amber-300 text-sm">
+          Browse markets →
+        </Link>
       </main>
     );
   }
 
-  const winRate = portfolio!.total_staked_xlm > 0
-    ? ((portfolio!.total_won_xlm / portfolio!.total_staked_xlm) * 100).toFixed(1)
-    : '0.0';
+  const pendingCount = portfolio!.pending_claims.length;
 
   return (
     <main className="max-w-4xl mx-auto px-4 py-8 space-y-8">
-      {/* Stats — 2 cols on mobile, 4 on sm+ */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-        {[
-          { label: 'Total Staked', value: `${portfolio!.total_staked_xlm.toFixed(2)} XLM` },
-          { label: 'Total Won',    value: `${portfolio!.total_won_xlm.toFixed(2)} XLM` },
-          { label: 'Total Lost',   value: `${portfolio!.total_lost_xlm.toFixed(2)} XLM` },
-          { label: 'Win Rate',     value: `${winRate}%` },
-        ].map(({ label, value }) => (
-          <div key={label} className="bg-gray-900 rounded-xl p-4 text-center">
-            <p className="text-xs text-gray-400">{label}</p>
-            <p className="text-base font-semibold text-white mt-1 break-words">{value}</p>
-          </div>
-        ))}
+      {/* Header */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <h1 className="text-xl font-bold text-white">My Portfolio</h1>
+        {pendingCount > 0 && (
+          <button
+            onClick={handleClaimAll}
+            disabled={claimingAll || claimTxStatus.status === 'pending'}
+            className="min-h-[44px] px-5 rounded-xl bg-amber-500 hover:bg-amber-400 disabled:opacity-50 disabled:cursor-not-allowed font-semibold text-black text-sm"
+          >
+            {claimingAll ? 'Claiming…' : `Claim All (${pendingCount})`}
+          </button>
+        )}
       </div>
 
-      {portfolio!.pending_claims.length > 0 && (
-        <section>
-          <h2 className="text-amber-400 font-semibold mb-3">Pending Claims</h2>
-          <BetHistoryTable bets={portfolio!.pending_claims} onClaim={claimWinnings} onRefund={claimRefund} />
-        </section>
-      )}
+      {/* Stats */}
+      <BettorStats
+        totalStaked={portfolio!.total_staked_xlm}
+        totalWon={portfolio!.total_won_xlm}
+        totalLost={portfolio!.total_lost_xlm}
+        pendingClaimsCount={pendingCount}
+      />
 
-      {portfolio!.active_bets.length > 0 && (
-        <section>
-          <h2 className="text-white font-semibold mb-3">Active Bets</h2>
-          <BetHistoryTable bets={portfolio!.active_bets} onClaim={claimWinnings} onRefund={claimRefund} />
-        </section>
-      )}
-
+      {/* Bet history */}
       <section>
         <h2 className="text-white font-semibold mb-3">Bet History</h2>
-        <BetHistoryTable bets={portfolio!.past_bets} onClaim={claimWinnings} onRefund={claimRefund} />
+        <BetHistoryTable
+          bets={allBets}
+          markets={marketsMap}
+          onClaim={claimWinnings}
+          onRefund={claimRefund}
+        />
       </section>
 
-      <TxStatusToast txStatus={displayStatus} onDismiss={handleDismiss} />
+      <TxStatusToast
+        txStatus={displayStatus}
+        onDismiss={() => setDismissedToast(true)}
+      />
     </main>
   );
 }

--- a/frontend/src/components/bet/BetHistoryTable.tsx
+++ b/frontend/src/components/bet/BetHistoryTable.tsx
@@ -1,115 +1,236 @@
+'use client';
+
 // ============================================================
 // BOXMEOUT — BetHistoryTable Component
 // ============================================================
 
-import { stellarExplorerUrl } from '../../services/wallet';
-import type { Bet } from '../../types';
+import { useState, useMemo } from 'react';
+import type { Bet, Market } from '../../types';
+
+type FilterTab = 'All' | 'Active' | 'Won' | 'Lost' | 'Pending Claim';
+type SortKey = 'placed_at' | 'amount_xlm';
+type SortDir = 'asc' | 'desc';
+
+const PAGE_SIZE = 10;
+const TABS: FilterTab[] = ['All', 'Active', 'Won', 'Lost', 'Pending Claim'];
+
+function getBetStatus(bet: Bet): 'Active' | 'Won' | 'Lost' | 'Pending Claim' | 'Claimed' {
+  if (bet.claimed) return 'Claimed';
+  const payout = bet.payout !== null ? parseFloat(bet.payout) : null;
+  if (payout === null) return 'Active';
+  if (payout > 0) return 'Pending Claim';
+  return 'Lost';
+}
 
 interface BetHistoryTableProps {
   bets: Bet[];
-  /** Called when user clicks "Claim" on an eligible row */
-  onClaim: (market_contract_address: string) => void;
-  /** Called when user clicks "Refund" on a cancelled market row */
-  onRefund: (market_contract_address: string) => void;
+  /** Optional map of market_id → Market for displaying fighter names */
+  markets?: Record<string, Market>;
+  onClaim: (market_id: string) => void;
+  onRefund: (market_id: string) => void;
 }
 
-/**
- * Table of bets, typically shown on the Portfolio page.
- *
- * Columns: Market | Side | Amount (XLM) | Status | Payout (XLM) | Action
- *
- * Action column rules:
- *   - Bet is on winning side + unclaimed  → show "Claim" button
- *   - Market is cancelled + unclaimed     → show "Refund" button
- *   - Already claimed                     → show payout amount in green
- *   - Bet lost                            → show "-" (no action)
- *   - Market not yet resolved             → show "Pending"
- *
- * Renders an empty state message when bets array is empty.
- */
-export function BetHistoryTable({
-  bets,
-  onClaim,
-  onRefund,
-}: BetHistoryTableProps): JSX.Element {
+export function BetHistoryTable({ bets, markets, onClaim, onRefund }: BetHistoryTableProps): JSX.Element {
+  const [tab, setTab] = useState<FilterTab>('All');
+  const [sortKey, setSortKey] = useState<SortKey>('placed_at');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [page, setPage] = useState(1);
+
+  const handleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir('desc');
+    }
+    setPage(1);
+  };
+
+  const filtered = useMemo(() => {
+    return bets.filter((bet) => {
+      if (tab === 'All') return true;
+      const status = getBetStatus(bet);
+      if (tab === 'Active') return status === 'Active';
+      if (tab === 'Won') return status === 'Claimed';
+      if (tab === 'Lost') return status === 'Lost';
+      if (tab === 'Pending Claim') return status === 'Pending Claim';
+      return true;
+    });
+  }, [bets, tab]);
+
+  const sorted = useMemo(() => {
+    return [...filtered].sort((a, b) => {
+      let cmp = 0;
+      if (sortKey === 'placed_at') {
+        cmp = new Date(a.placed_at).getTime() - new Date(b.placed_at).getTime();
+      } else {
+        cmp = a.amount_xlm - b.amount_xlm;
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [filtered, sortKey, sortDir]);
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const paginated = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  const SortIcon = ({ col }: { col: SortKey }) =>
+    sortKey === col ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ' ↕';
+
   if (bets.length === 0) {
     return <p className="text-gray-500 text-sm text-center py-6">No bets yet.</p>;
   }
 
   return (
-    <div className="overflow-x-auto -mx-4 px-4">
-      <table className="min-w-full text-sm text-left text-gray-300">
-        <thead>
-          <tr className="text-xs text-gray-500 border-b border-gray-800">
-            <th className="pb-2 pr-4 whitespace-nowrap">Market</th>
-            <th className="pb-2 pr-4 whitespace-nowrap">Side</th>
-            <th className="pb-2 pr-4 whitespace-nowrap">Amount (XLM)</th>
-            <th className="pb-2 pr-4 whitespace-nowrap">Status</th>
-            <th className="pb-2 pr-4 whitespace-nowrap">Payout (XLM)</th>
-            <th className="pb-2 whitespace-nowrap">Action</th>
-          </tr>
-        </thead>
-        <tbody>
-          {bets.map((bet) => {
-            const payout = bet.payout ? parseFloat(bet.payout) : null;
+    <div className="space-y-3">
+      {/* Filter tabs */}
+      <div className="flex gap-1 flex-wrap">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            onClick={() => { setTab(t); setPage(1); }}
+            className={`min-h-[36px] px-3 rounded-lg text-xs font-medium transition-colors ${
+              tab === t
+                ? 'bg-amber-500 text-black'
+                : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-white'
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
 
-            let action: JSX.Element;
-            if (bet.claimed) {
-              action = <span className="text-green-400">{payout != null ? `${payout.toFixed(2)} XLM` : '—'}</span>;
-            } else if (payout != null && payout > 0) {
-              action = (
-                <button
-                  onClick={() => onClaim(bet.market_id)}
-                  className="min-h-[44px] px-3 rounded-lg bg-amber-500 hover:bg-amber-400 font-semibold text-black text-xs"
-                >
-                  Claim
-                </button>
-              );
-            } else if (payout != null && payout < 0) {
-              action = (
-                <button
-                  onClick={() => onRefund(bet.market_id)}
-                  className="min-h-[44px] px-3 rounded-lg bg-gray-700 hover:bg-gray-600 text-xs"
-                >
-                  Refund
-                </button>
-              );
-            } else if (payout === 0) {
-              action = <span className="text-gray-500">—</span>;
-            } else {
-              action = <span className="text-gray-500">Pending</span>;
-            }
-
-            return (
-              <tr key={bet.tx_hash} className="border-b border-gray-800/50 group">
-                <td className="py-3 pr-4 font-mono text-xs whitespace-nowrap">
-                  <a
-                    href={stellarExplorerUrl('tx', bet.tx_hash)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-amber-400 hover:text-amber-300 hover:underline"
-                    title={bet.tx_hash}
-                  >
-                    {bet.market_id.slice(0, 8)}…
-                  </a>
+      {/* Table */}
+      <div className="overflow-x-auto -mx-4 px-4">
+        <table className="min-w-full text-sm text-left text-gray-300">
+          <thead>
+            <tr className="text-xs text-gray-500 border-b border-gray-800">
+              <th className="pb-2 pr-4 whitespace-nowrap">Market</th>
+              <th className="pb-2 pr-4 whitespace-nowrap">My Bet</th>
+              <th
+                className="pb-2 pr-4 whitespace-nowrap cursor-pointer hover:text-gray-300 select-none"
+                onClick={() => handleSort('amount_xlm')}
+              >
+                Amount<SortIcon col="amount_xlm" />
+              </th>
+              <th className="pb-2 pr-4 whitespace-nowrap">Odds</th>
+              <th className="pb-2 pr-4 whitespace-nowrap">Status</th>
+              <th className="pb-2 pr-4 whitespace-nowrap">Payout</th>
+              <th
+                className="pb-2 pr-4 whitespace-nowrap cursor-pointer hover:text-gray-300 select-none"
+                onClick={() => handleSort('placed_at')}
+              >
+                Date<SortIcon col="placed_at" />
+              </th>
+              <th className="pb-2 whitespace-nowrap">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {paginated.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="py-6 text-center text-gray-500 text-sm">
+                  No bets in this category.
                 </td>
-                <td className="py-3 pr-4 capitalize whitespace-nowrap">{bet.side.replace('_', ' ')}</td>
-                <td className="py-3 pr-4 whitespace-nowrap">{bet.amount_xlm} XLM</td>
-                <td className="py-3 pr-4 whitespace-nowrap">
-                  {bet.claimed 
-                    ? 'Claimed' 
-                    : payout != null 
-                      ? (payout > 0 ? 'Won' : payout < 0 ? 'Cancelled' : 'Lost') 
-                      : 'Active'
-                  }
-                </td>
-                <td className="py-3 pr-4 whitespace-nowrap">{payout != null ? `${payout.toFixed(2)} XLM` : '—'}</td>
-                <td className="py-3 whitespace-nowrap">{action}</td>
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
+            ) : (
+              paginated.map((bet) => {
+                const market = markets?.[bet.market_id];
+                const marketLabel = market
+                  ? `${market.fighter_a} vs ${market.fighter_b}`
+                  : bet.market_id.slice(0, 8) + '…';
+                const sideLabel = bet.side === 'fighter_a'
+                  ? market?.fighter_a ?? 'Fighter A'
+                  : bet.side === 'fighter_b'
+                  ? market?.fighter_b ?? 'Fighter B'
+                  : 'Draw';
+                const payout = bet.payout !== null ? parseFloat(bet.payout) : null;
+                const status = getBetStatus(bet);
+
+                // Odds: derive from market if available
+                const oddsVal = market
+                  ? bet.side === 'fighter_a'
+                    ? (market.odds_a / 100).toFixed(0) + '%'
+                    : bet.side === 'fighter_b'
+                    ? (market.odds_b / 100).toFixed(0) + '%'
+                    : (market.odds_draw / 100).toFixed(0) + '%'
+                  : '—';
+
+                let action: JSX.Element;
+                if (status === 'Pending Claim') {
+                  action = (
+                    <button
+                      onClick={() => onClaim(bet.market_id)}
+                      className="min-h-[36px] px-3 rounded-lg bg-amber-500 hover:bg-amber-400 font-semibold text-black text-xs"
+                    >
+                      Claim
+                    </button>
+                  );
+                } else if (payout !== null && payout < 0) {
+                  action = (
+                    <button
+                      onClick={() => onRefund(bet.market_id)}
+                      className="min-h-[36px] px-3 rounded-lg bg-gray-700 hover:bg-gray-600 text-xs"
+                    >
+                      Refund
+                    </button>
+                  );
+                } else {
+                  action = <span className="text-gray-600">—</span>;
+                }
+
+                const statusColor =
+                  status === 'Claimed' ? 'text-green-400'
+                  : status === 'Pending Claim' ? 'text-amber-400'
+                  : status === 'Lost' ? 'text-red-400'
+                  : 'text-gray-400';
+
+                return (
+                  <tr key={bet.tx_hash} className="border-b border-gray-800/50">
+                    <td className="py-3 pr-4 text-xs whitespace-nowrap text-gray-300">{marketLabel}</td>
+                    <td className="py-3 pr-4 whitespace-nowrap">{sideLabel}</td>
+                    <td className="py-3 pr-4 whitespace-nowrap">{bet.amount_xlm} XLM</td>
+                    <td className="py-3 pr-4 whitespace-nowrap text-gray-400">{oddsVal}</td>
+                    <td className={`py-3 pr-4 whitespace-nowrap text-xs font-medium ${statusColor}`}>
+                      {status}
+                    </td>
+                    <td className="py-3 pr-4 whitespace-nowrap">
+                      {payout !== null && payout >= 0 ? `${payout.toFixed(2)} XLM` : '—'}
+                    </td>
+                    <td className="py-3 pr-4 whitespace-nowrap text-xs text-gray-500">
+                      {new Date(bet.placed_at).toLocaleDateString()}
+                    </td>
+                    <td className="py-3 whitespace-nowrap">{action}</td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between text-xs text-gray-400 pt-1">
+          <span>
+            {(page - 1) * PAGE_SIZE + 1}–{Math.min(page * PAGE_SIZE, sorted.length)} of {sorted.length}
+          </span>
+          <div className="flex gap-1">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="min-h-[32px] px-3 rounded-lg bg-gray-800 hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              ←
+            </button>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="min-h-[32px] px-3 rounded-lg bg-gray-800 hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              →
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/market/FighterCard.tsx
+++ b/frontend/src/components/market/FighterCard.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+// ============================================================
+// BOXMEOUT — FighterCard Component
+// Used on the market detail page to display each fighter.
+// ============================================================
+
+import Image from 'next/image';
+
+interface FighterCardProps {
+  name: string;
+  /** Implied probability in basis points (0–10000) */
+  odds: number;
+  /** Pool amount in stroops (i128 string) */
+  poolAmount: string;
+  /** Optional photo URL; falls back to placeholder */
+  photoUrl?: string;
+  /** Highlight border when user has bet on this fighter */
+  isUserBet?: boolean;
+  /** Show trophy icon if this fighter won */
+  isWinner?: boolean;
+}
+
+export function FighterCard({
+  name,
+  odds,
+  poolAmount,
+  photoUrl,
+  isUserBet = false,
+  isWinner = false,
+}: FighterCardProps): JSX.Element {
+  const oddsPercent = (odds / 100).toFixed(1);
+  const poolXlm = (parseInt(poolAmount, 10) / 1e7).toLocaleString(undefined, {
+    maximumFractionDigits: 0,
+  });
+
+  return (
+    <div
+      className={`flex flex-col items-center gap-3 rounded-xl bg-gray-900 p-5 transition-colors ${
+        isUserBet
+          ? 'ring-2 ring-amber-400'
+          : 'ring-1 ring-gray-800'
+      }`}
+    >
+      {/* Avatar */}
+      <div className="relative w-20 h-20 rounded-full overflow-hidden bg-gray-800 flex items-center justify-center shrink-0">
+        {photoUrl ? (
+          <Image src={photoUrl} alt={name} fill className="object-cover" sizes="80px" />
+        ) : (
+          <span className="text-3xl select-none">🥊</span>
+        )}
+        {isWinner && (
+          <span
+            className="absolute -top-1 -right-1 text-lg leading-none"
+            title="Winner"
+            aria-label="Winner"
+          >
+            🏆
+          </span>
+        )}
+      </div>
+
+      {/* Name */}
+      <p className="font-bold text-white text-center text-sm leading-tight">{name}</p>
+
+      {/* Odds */}
+      <div className="text-center">
+        <p className="text-2xl font-bold text-amber-400">{oddsPercent}%</p>
+        <p className="text-xs text-gray-500 mt-0.5">implied odds</p>
+      </div>
+
+      {/* Pool */}
+      <div className="text-center">
+        <p className="text-sm font-semibold text-white">{poolXlm} XLM</p>
+        <p className="text-xs text-gray-500">in pool</p>
+      </div>
+
+      {isUserBet && (
+        <span className="text-xs text-amber-400 font-medium bg-amber-400/10 px-2 py-0.5 rounded-full">
+          Your pick
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/market/MarketCard.tsx
+++ b/frontend/src/components/market/MarketCard.tsx
@@ -49,7 +49,7 @@ export function MarketCard({ market }: MarketCardProps): JSX.Element {
 
       {/* Footer */}
       <div className="flex items-center justify-between text-xs text-gray-400">
-        <CountdownTimer scheduled_at={market.scheduled_at} label="Starts in" />
+        <CountdownTimer targetDate={market.scheduled_at} label="Starts in" />
         <span>{totalXlm} XLM pooled</span>
       </div>
     </Link>

--- a/frontend/src/components/ui/CountdownTimer.tsx
+++ b/frontend/src/components/ui/CountdownTimer.tsx
@@ -1,46 +1,49 @@
+'use client';
+
 // ============================================================
 // BOXMEOUT — CountdownTimer Component
 // ============================================================
 
-import { useMarketCountdown } from '@/hooks/useMarketCountdown';
+import { useState, useEffect } from 'react';
 
 interface CountdownTimerProps {
-  /** ISO 8601 timestamp of fight start */
-  scheduled_at: string;
-  /** Optional label prefix (e.g. "Starts in") */
+  /** ISO 8601 timestamp of target time */
+  targetDate: string;
+  /** Optional label for context (e.g. "Betting closes in") */
   label?: string;
 }
 
-/**
- * Renders a live countdown to the fight start time.
- * Uses the useMarketCountdown hook internally.
- *
- * Display:
- *   "Starts in 2h 14m 32s"   → while countdown is running
- *   "LIVE"                    → when fight has started (red pulsing badge)
- *   "ENDED"                   → after resolution window passed
- */
-export function CountdownTimer({
-  scheduled_at,
-  label = 'Starts in',
-}: CountdownTimerProps): JSX.Element {
-  const state = useMarketCountdown(scheduled_at);
+function formatDDHHMMSS(ms: number): string {
+  const totalSec = Math.max(0, Math.floor(ms / 1000));
+  const dd = Math.floor(totalSec / 86400);
+  const hh = Math.floor((totalSec % 86400) / 3600);
+  const mm = Math.floor((totalSec % 3600) / 60);
+  const ss = totalSec % 60;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(dd)}:${pad(hh)}:${pad(mm)}:${pad(ss)}`;
+}
 
-  if (state === 'LIVE') {
-    return (
-      <span className="inline-flex items-center gap-1.5 rounded-full bg-red-600 px-2.5 py-0.5 text-xs font-semibold text-white animate-pulse">
-        LIVE
-      </span>
-    );
-  }
+export function CountdownTimer({ targetDate, label }: CountdownTimerProps): JSX.Element {
+  const targetMs = new Date(targetDate).getTime();
+  const [remaining, setRemaining] = useState(() => targetMs - Date.now());
 
-  if (state === 'ENDED') {
-    return <span className="text-sm text-gray-400">ENDED</span>;
+  useEffect(() => {
+    const id = setInterval(() => {
+      const r = targetMs - Date.now();
+      setRemaining(r);
+      if (r <= 0) clearInterval(id);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [targetMs]);
+
+  if (remaining <= 0) {
+    return <span className="text-sm text-gray-400">Betting Closed</span>;
   }
 
   return (
     <span className="text-sm text-gray-200">
-      {label} {state}
+      {label && <span className="text-gray-400 mr-1">{label}</span>}
+      <span className="font-mono text-amber-400">{formatDDHHMMSS(remaining)}</span>
     </span>
   );
 }


### PR DESCRIPTION
closes #777  
closes #778 
closes #776 
closes #779 


…mer, and fighter card

BetHistoryTable (src/components/bet/BetHistoryTable.tsx)
- Add filter tabs: All / Active / Won / Lost / Pending Claim
- Add sortable columns: Amount (XLM) and Date with asc/desc toggle
- Add pagination (10 rows/page) with prev/next controls and row count
- Add columns: Market (fighter names), My Bet, Amount, Odds, Status, Payout, Date, Action
- Claim button on Pending Claim rows calls onClaim(market_id)
- Accept optional markets map for resolving fighter names from market_id

CountdownTimer (src/components/ui/CountdownTimer.tsx)
- Rewrite to use own setInterval instead of useMarketCountdown hook
- Format as DD:HH:MM:SS, updating every second
- Clean up interval on unmount
- Show 'Betting Closed' when target time is reached
- Accept label prop for context (e.g. 'Betting closes in')
- Rename prop scheduled_at -> targetDate; update callers in MarketCard and MarketDetailContent

FighterCard (src/components/market/FighterCard.tsx) [new]
- Show fighter name, implied odds (%), and pool amount in XLM
- Optional photoUrl via next/image with 🥊 emoji fallback
- Trophy icon overlay when isWinner=true
- Amber ring border + 'Your pick' badge when isUserBet=true

Portfolio page (src/app/portfolio/page.tsx)
- Add BettorStats summary: Total Staked, Won, Lost, Win Rate, Pending Claims count
- Add Claim All button iterating pending_claims deduped by market_id (one tx each)
- Redirect to ConnectPrompt when wallet not connected
- Show empty state with link to browse markets when no bets placed
- Merge all bets (pending + active + past) into single BetHistoryTable with markets map

## Closes

Closes #

## What this PR does

<!-- One paragraph. What did you implement? Do not explain how — the code does that. -->

## Testing

<!-- How did you verify this works? What test cases did you add? -->

## Screenshots (frontend changes only)

<!-- Add before/after screenshots or a short screen recording. -->

## Checklist

- [ ] I have read `docs/contributing.md`
- [ ] My code follows the naming conventions in the guidelines
- [ ] I have added or updated tests for my changes
- [ ] All tests pass locally (`cargo test` / `npm test`)
- [ ] Lint passes (`cargo clippy` / `npm run lint`)
- [ ] No `console.log` or `unwrap()` left in production paths
- [ ] No secrets committed
