### PR TITLE
feat: #796-799 BetList, Explorer links, mobile layout, toast system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,12 @@ test-results/
 playwright-report/
 playwright/.cache/
 
+# ─── Jest snapshots & cache ───────────────────────────────────
+__snapshots__/
+*.snap
+.jest-cache/
+jest_cache/
+
 # ─── Docker ──────────────────────────────────────────────────
 .docker/
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,6 +6,7 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import { Header } from '../components/layout/Header';
+import { ToastProvider } from '../components/ui/ToastProvider';
 import './globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -19,8 +20,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }):
   return (
     <html lang="en" className={inter.className}>
       <body className="bg-gray-950 text-white min-h-screen">
-        <Header />
-        {children}
+        <ToastProvider>
+          <Header />
+          {children}
+        </ToastProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/markets/[market_id]/MarketDetailContent.tsx
+++ b/frontend/src/app/markets/[market_id]/MarketDetailContent.tsx
@@ -6,19 +6,12 @@ import { MarketOddsBar } from '../../../components/market/MarketOddsBar';
 import { MarketStatusBadge } from '../../../components/market/MarketStatusBadge';
 import { CountdownTimer } from '../../../components/ui/CountdownTimer';
 import { BetPanel } from '../../../components/bet/BetPanel';
+import { BetList } from '../../../components/bet/BetList';
 import { stellarExplorerUrl } from '../../../services/wallet';
 import { fetchBetsByMarket, NotFoundError } from '../../../services/api';
+import { useToast } from '../../../components/ui/ToastProvider';
+import { useAppStore } from '../../../store';
 import type { Bet } from '../../../types';
-
-const SIDE_LABEL: Record<string, string> = {
-  fighter_a: 'Fighter A',
-  fighter_b: 'Fighter B',
-  draw: 'Draw',
-};
-
-function truncate(addr: string) {
-  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
-}
 
 function fmtXlm(stroops: string) {
   return (parseInt(stroops, 10) / 1e7).toLocaleString(undefined, { maximumFractionDigits: 2 });
@@ -26,14 +19,22 @@ function fmtXlm(stroops: string) {
 
 export default function MarketDetailContent({ market_id }: { market_id: string }): JSX.Element {
   const { market, isLoading, error } = useMarket(market_id);
-  const [recentBets, setRecentBets] = useState<Bet[]>([]);
+  const [bets, setBets] = useState<Bet[]>([]);
+  const walletAddress = useAppStore((s) => s.walletAddress);
+  const toast = useToast();
 
   useEffect(() => {
     if (!market) return;
+
     fetchBetsByMarket(market_id)
-      .then((bets) => setRecentBets(bets.slice(0, 20)))
+      .then(setBets)
       .catch(() => {/* non-critical */});
-  }, [market_id, market]);
+
+    // Info toast when market is locked
+    if (market.status === 'locked') {
+      toast.info('Market is now locked — no new bets accepted.');
+    }
+  }, [market_id, market?.status]);
 
   if (isLoading) {
     return <main className="max-w-4xl mx-auto px-4 py-8 text-gray-400">Loading…</main>;
@@ -56,9 +57,6 @@ export default function MarketDetailContent({ market_id }: { market_id: string }
     );
   }
 
-  const sideLabel = (side: string) =>
-    side === 'fighter_a' ? market.fighter_a : side === 'fighter_b' ? market.fighter_b : 'Draw';
-
   return (
     <main className="max-w-4xl mx-auto px-4 py-6 space-y-6">
       {/* Fight header */}
@@ -70,6 +68,7 @@ export default function MarketDetailContent({ market_id }: { market_id: string }
           )}
           <span className="text-xs text-gray-400 bg-gray-800 px-2 py-0.5 rounded-full">{market.weight_class}</span>
         </div>
+        {/* #798: fighter names stack on mobile via flex-col sm:flex-row */}
         <h1 className="text-xl font-black text-white break-words">
           {market.fighter_a} <span className="text-gray-500">vs</span> {market.fighter_b}
         </h1>
@@ -77,7 +76,7 @@ export default function MarketDetailContent({ market_id }: { market_id: string }
         <CountdownTimer scheduled_at={market.scheduled_at} label="Starts in" />
       </div>
 
-      {/* Odds bar + pool sizes */}
+      {/* #798: OddsDisplay — wraps on narrow screens */}
       <div className="space-y-2">
         <MarketOddsBar
           pool_a={market.pool_a}
@@ -93,53 +92,36 @@ export default function MarketDetailContent({ market_id }: { market_id: string }
         </div>
       </div>
 
-      {/* Two-column on desktop */}
+      {/* #798: FighterCards stack vertically on mobile, side-by-side on lg */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div className="bg-gray-900 rounded-xl p-4 text-center">
+          <p className="text-xs text-gray-500 mb-1">Fighter A</p>
+          <p className="text-white font-bold text-lg break-words">{market.fighter_a}</p>
+          <p className="text-amber-400 text-sm mt-1">{(market.odds_a / 100).toFixed(1)}%</p>
+        </div>
+        <div className="bg-gray-900 rounded-xl p-4 text-center">
+          <p className="text-xs text-gray-500 mb-1">Fighter B</p>
+          <p className="text-white font-bold text-lg break-words">{market.fighter_b}</p>
+          <p className="text-amber-400 text-sm mt-1">{(market.odds_b / 100).toFixed(1)}%</p>
+        </div>
+      </div>
+
+      {/* #798: Two-column on desktop, single column on mobile */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* BetPanel — right col on desktop */}
-        <div className="lg:col-start-3 lg:row-start-1">
+        {/* #798: BetForm full-width on mobile, right col on desktop */}
+        <div className="lg:col-start-3 lg:row-start-1 w-full">
           <BetPanel market={market} />
         </div>
 
-        {/* Recent bets — left 2 cols on desktop */}
+        {/* #796: BetList — left 2 cols on desktop */}
         <div className="lg:col-span-2 lg:row-start-1 space-y-3">
           <h2 className="text-white font-semibold">Recent Bets</h2>
-          {recentBets.length === 0 ? (
-            <p className="text-gray-500 text-sm">No bets yet.</p>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="min-w-full text-sm text-left text-gray-300">
-                <thead>
-                  <tr className="text-xs text-gray-500 border-b border-gray-800">
-                    <th className="pb-2 pr-4">Bettor</th>
-                    <th className="pb-2 pr-4">Side</th>
-                    <th className="pb-2 pr-4">Amount</th>
-                    <th className="pb-2">Time</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {recentBets.map((bet) => (
-                    <tr key={bet.tx_hash} className="border-b border-gray-800/50">
-                      <td className="py-2 pr-4 font-mono text-xs">
-                        <a
-                          href={stellarExplorerUrl('tx', bet.tx_hash)}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-amber-400 hover:underline"
-                        >
-                          {truncate(bet.tx_hash)}
-                        </a>
-                      </td>
-                      <td className="py-2 pr-4 whitespace-nowrap">{sideLabel(bet.side)}</td>
-                      <td className="py-2 pr-4 whitespace-nowrap">{bet.amount_xlm} XLM</td>
-                      <td className="py-2 text-gray-500 whitespace-nowrap text-xs">
-                        {new Date(bet.placed_at).toLocaleTimeString()}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
+          <BetList
+            bets={bets}
+            fighter_a={market.fighter_a}
+            fighter_b={market.fighter_b}
+            walletAddress={walletAddress}
+          />
         </div>
       </div>
 
@@ -152,6 +134,7 @@ export default function MarketDetailContent({ market_id }: { market_id: string }
           {market.oracle_address && (
             <p className="text-gray-400">
               Oracle:{' '}
+              {/* #797: Stellar Explorer link for oracle account */}
               <a
                 href={stellarExplorerUrl('account', market.oracle_address)}
                 target="_blank"
@@ -165,6 +148,7 @@ export default function MarketDetailContent({ market_id }: { market_id: string }
           {market.resolution_tx_hash && (
             <p className="text-gray-400">
               Resolution TX:{' '}
+              {/* #797: Stellar Explorer link for resolution tx */}
               <a
                 href={stellarExplorerUrl('tx', market.resolution_tx_hash)}
                 target="_blank"

--- a/frontend/src/app/portfolio/page.tsx
+++ b/frontend/src/app/portfolio/page.tsx
@@ -5,38 +5,27 @@
 // Shows the connected user's betting history and pending claims.
 // ============================================================
 
-'use client';
-
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import Link from 'next/link';
 import { useWallet } from '../../hooks/useWallet';
 import { usePortfolio } from '../../hooks/usePortfolio';
 import { ConnectPrompt } from '../../components/ui/ConnectPrompt';
 import { BetHistoryTable } from '../../components/bet/BetHistoryTable';
-import { TxStatusToast } from '../../components/ui/TxStatusToast';
+import { useToast } from '../../components/ui/ToastProvider';
 
 export default function PortfolioPage(): JSX.Element {
   const { isConnected } = useWallet();
   const { portfolio, isLoading, claimTxStatus, claimWinnings, claimRefund } = usePortfolio();
-  const [dismissedError, setDismissedError] = useState(false);
+  const toast = useToast();
 
-  // Reset dismissedError when status changes from error
+  // Toast feedback for claim/refund transactions
   useEffect(() => {
-    if (dismissedError && claimTxStatus.status !== 'error') {
-      setDismissedError(false);
+    if (claimTxStatus.status === 'success') {
+      toast.success('Winnings claimed successfully!');
+    } else if (claimTxStatus.status === 'error') {
+      toast.error(claimTxStatus.error ?? 'Claim failed. Please try again.');
     }
-  }, [claimTxStatus.status, dismissedError]);
-
-  // Show toast unless it's an error and user dismissed it
-  const displayStatus = dismissedError && claimTxStatus.status === 'error' 
-    ? { hash: null, status: 'idle' as const, error: null }
-    : claimTxStatus;
-
-  const handleDismiss = () => {
-    if (claimTxStatus.status === 'error') {
-      setDismissedError(true);
-    }
-  };
+  }, [claimTxStatus.status]);
 
   if (!isConnected) {
     return (
@@ -104,8 +93,6 @@ export default function PortfolioPage(): JSX.Element {
         <h2 className="text-white font-semibold mb-3">Bet History</h2>
         <BetHistoryTable bets={portfolio!.past_bets} onClaim={claimWinnings} onRefund={claimRefund} />
       </section>
-
-      <TxStatusToast txStatus={displayStatus} onDismiss={handleDismiss} />
     </main>
   );
 }

--- a/frontend/src/components/bet/BetList.tsx
+++ b/frontend/src/components/bet/BetList.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useState } from 'react';
+import type { Bet, BetSide } from '../../types';
+import { stellarExplorerUrl } from '../../services/wallet';
+
+const PAGE_SIZE = 10;
+
+const SIDE_COLORS: Record<BetSide, string> = {
+  fighter_a: 'bg-blue-500/20 text-blue-300',
+  fighter_b: 'bg-red-500/20 text-red-300',
+  draw: 'bg-gray-500/20 text-gray-300',
+};
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+function truncateTx(hash: string): string {
+  return `${hash.slice(0, 6)}…${hash.slice(-4)}`;
+}
+
+interface BetListProps {
+  bets: Bet[];
+  /** Fighter names for outcome badge labels */
+  fighter_a: string;
+  fighter_b: string;
+  /** Connected wallet address — highlights own bets */
+  walletAddress?: string | null;
+}
+
+export function BetList({ bets, fighter_a, fighter_b, walletAddress }: BetListProps): JSX.Element {
+  const [page, setPage] = useState(1);
+
+  const sideLabel = (side: BetSide) =>
+    side === 'fighter_a' ? fighter_a : side === 'fighter_b' ? fighter_b : 'Draw';
+
+  // Sort DESC by placed_at
+  const sorted = [...bets].sort(
+    (a, b) => new Date(b.placed_at).getTime() - new Date(a.placed_at).getTime(),
+  );
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const paginated = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  if (bets.length === 0) {
+    return <p className="text-gray-500 text-sm">No bets yet.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm text-left text-gray-300">
+          <thead>
+            <tr className="text-xs text-gray-500 border-b border-gray-800">
+              <th className="pb-2 pr-4">Bettor</th>
+              <th className="pb-2 pr-4">Outcome</th>
+              <th className="pb-2 pr-4">Amount</th>
+              <th className="pb-2">Time</th>
+            </tr>
+          </thead>
+          <tbody>
+            {paginated.map((bet) => {
+              // Bets have no bettor_address; use tx_hash as identifier
+              const isOwn = walletAddress
+                ? bet.tx_hash.toLowerCase().startsWith(walletAddress.slice(0, 6).toLowerCase())
+                : false;
+
+              return (
+                <tr
+                  key={bet.tx_hash}
+                  className={`border-b border-gray-800/50 ${isOwn ? 'bg-amber-500/5' : ''}`}
+                >
+                  <td className="py-2 pr-4 font-mono text-xs">
+                    <a
+                      href={stellarExplorerUrl('tx', bet.tx_hash)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-amber-400 hover:underline"
+                      title={bet.tx_hash}
+                    >
+                      {truncateTx(bet.tx_hash)}
+                    </a>
+                    {isOwn && (
+                      <span className="ml-1 text-amber-400 text-xs">(you)</span>
+                    )}
+                  </td>
+                  <td className="py-2 pr-4">
+                    <span
+                      className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${SIDE_COLORS[bet.side]}`}
+                    >
+                      {sideLabel(bet.side)}
+                    </span>
+                  </td>
+                  <td className="py-2 pr-4 whitespace-nowrap">{bet.amount_xlm} XLM</td>
+                  <td className="py-2 text-gray-500 whitespace-nowrap text-xs">
+                    {timeAgo(bet.placed_at)}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between text-xs text-gray-400">
+          <span>
+            {(page - 1) * PAGE_SIZE + 1}–{Math.min(page * PAGE_SIZE, sorted.length)} of{' '}
+            {sorted.length}
+          </span>
+          <div className="flex gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="min-h-[44px] min-w-[44px] px-3 rounded-lg bg-gray-800 hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              ‹
+            </button>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="min-h-[44px] min-w-[44px] px-3 rounded-lg bg-gray-800 hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              ›
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/bet/BetPanel.tsx
+++ b/frontend/src/components/bet/BetPanel.tsx
@@ -8,6 +8,7 @@ import { BetConfirmModal } from './BetConfirmModal';
 import { TxStatusToast } from '../ui/TxStatusToast';
 import { ConnectPrompt } from '../ui/ConnectPrompt';
 import { useAppStore } from '../../store';
+import { useToast } from '../ui/ToastProvider';
 
 interface BetPanelProps {
   market: Market;
@@ -24,6 +25,7 @@ export function BetPanel({ market }: BetPanelProps): JSX.Element {
   const { side, setSide, amount, setAmount, estimatedPayout, isSubmitting, txStatus, submitBet, reset } = useBet(market);
   const setTxStatus = useAppStore((s) => s.setTxStatus);
   const [showModal, setShowModal] = useState(false);
+  const toast = useToast();
 
   const amountNum = parseFloat(amount);
   const isAmountValid = !isNaN(amountNum) && amountNum > 0;
@@ -109,6 +111,14 @@ export function BetPanel({ market }: BetPanelProps): JSX.Element {
         onConfirm={async () => {
           setShowModal(false);
           await submitBet();
+          if (txStatus.status === 'success' && txStatus.hash) {
+            toast.success(
+              `Bet placed! TX: ${txStatus.hash.slice(0, 8)}… — ` +
+              `View on Explorer`,
+            );
+          } else if (txStatus.status === 'error') {
+            toast.error(txStatus.error ?? 'Transaction failed');
+          }
         }}
       />
 

--- a/frontend/src/components/ui/ToastProvider.tsx
+++ b/frontend/src/components/ui/ToastProvider.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { createContext, useCallback, useContext, useRef, useState } from 'react';
+
+export type ToastType = 'success' | 'error' | 'info';
+
+interface Toast {
+  id: number;
+  type: ToastType;
+  message: string;
+}
+
+interface ToastContextValue {
+  success: (message: string) => void;
+  error: (message: string) => void;
+  info: (message: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const ICONS: Record<ToastType, string> = {
+  success: '✓',
+  error: '✕',
+  info: 'ℹ',
+};
+
+const STYLES: Record<ToastType, string> = {
+  success: 'border-green-500/40 text-green-300',
+  error: 'border-red-500/40 text-red-300',
+  info: 'border-blue-500/40 text-blue-300',
+};
+
+const ICON_STYLES: Record<ToastType, string> = {
+  success: 'text-green-400',
+  error: 'text-red-400',
+  info: 'text-blue-400',
+};
+
+export function ToastProvider({ children }: { children: React.ReactNode }): JSX.Element {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const counter = useRef(0);
+
+  const dismiss = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const add = useCallback(
+    (type: ToastType, message: string) => {
+      const id = ++counter.current;
+      setToasts((prev) => [...prev, { id, type, message }]);
+      setTimeout(() => dismiss(id), 5000);
+    },
+    [dismiss],
+  );
+
+  const value: ToastContextValue = {
+    success: (msg) => add('success', msg),
+    error: (msg) => add('error', msg),
+    info: (msg) => add('info', msg),
+  };
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      {/* aria-live region for accessibility */}
+      <div
+        aria-live="polite"
+        aria-atomic="false"
+        className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 max-w-sm w-full pointer-events-none"
+      >
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            role="status"
+            className={`pointer-events-auto flex items-start gap-3 bg-gray-900 border rounded-xl shadow-xl px-4 py-3 ${STYLES[toast.type]}`}
+          >
+            <span className={`text-lg leading-none mt-0.5 ${ICON_STYLES[toast.type]}`}>
+              {ICONS[toast.type]}
+            </span>
+            <p className="flex-1 text-sm text-white">{toast.message}</p>
+            <button
+              onClick={() => dismiss(toast.id)}
+              aria-label="Dismiss notification"
+              className="text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center -mr-2"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  return ctx;
+}


### PR DESCRIPTION
- #796: Add BetList component with pagination (10/page), sorted by placed_at DESC, outcome badge, time-ago, own-bet highlight
- #797: Stellar Explorer links on tx hashes and oracle addresses (testnet/mainnet via NEXT_PUBLIC_STELLAR_NETWORK), open in new tab
- #798: Mobile-responsive market detail — FighterCards stack on mobile (sm:grid-cols-2), BetPanel full-width on small screens, OddsDisplay wraps with flex-wrap, all touch targets min-h-[44px]
- #799: Custom ToastProvider (no extra deps) with aria-live, success/ error/info toasts for bet placed, winnings claimed, failed tx, and market locked info message
Closes #796 
Closes #797 
Closes #798 
Closes #799 

