### PR TITLE
feat: implement #788 #789 #791 #792 frontend utils and hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,12 @@ Desktop.ini
 *.swo
 *~
 
+# ─── AI / IDE workspace files ────────────────────────────────
+.claude/
+.kiro/
+.cursor/
+.aider*
+
 # ─── Misc ────────────────────────────────────────────────────
 *.cache
 .cache/

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,121 @@
+// ============================================================
+// BOXMEOUT — API Client (lib)
+// Typed fetch wrappers for all backend REST endpoints.
+// Base URL from process.env.NEXT_PUBLIC_API_URL
+// ============================================================
+
+import type { Bet, Market, MarketStats, Portfolio } from '../src/types';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+
+// ─── Typed error ─────────────────────────────────────────────────────────────
+
+export class APIError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'APIError';
+  }
+}
+
+// ─── Core fetch helper ────────────────────────────────────────────────────────
+
+async function apiFetch<T>(path: string): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_BASE}${path}`);
+  } catch (e) {
+    throw new APIError(0, (e as Error).message);
+  }
+  if (!res.ok) {
+    throw new APIError(res.status, `API error ${res.status}: ${res.statusText}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface MarketFilters {
+  status?: string;
+  weight_class?: string;
+  search?: string;
+}
+
+export interface PaginationParams {
+  page?: number;
+  limit?: number;
+}
+
+export interface MarketListResponse {
+  markets: Market[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export interface MarketOdds {
+  market_id: string;
+  odds_a: number;
+  odds_b: number;
+  odds_draw: number;
+  pool_a: string;
+  pool_b: string;
+  pool_draw: string;
+  total_pool: string;
+}
+
+export interface PlatformStats {
+  total_markets: number;
+  open_markets: number;
+  total_volume_xlm: number;
+  total_bettors: number;
+}
+
+// ─── API functions ────────────────────────────────────────────────────────────
+
+/** GET /api/markets — list with optional filters and pagination */
+export async function fetchMarkets(
+  filters?: MarketFilters,
+  pagination?: PaginationParams,
+): Promise<MarketListResponse> {
+  const params = new URLSearchParams();
+  if (filters?.status) params.set('status', filters.status);
+  if (filters?.weight_class) params.set('weight_class', filters.weight_class);
+  if (filters?.search) params.set('search', filters.search);
+  if (pagination?.page) params.set('page', pagination.page.toString());
+  if (pagination?.limit) params.set('limit', pagination.limit.toString());
+  const qs = params.toString();
+  return apiFetch<MarketListResponse>(`/api/markets${qs ? `?${qs}` : ''}`);
+}
+
+/** GET /api/markets/:market_id — single market with live odds */
+export async function fetchMarketById(market_id: string): Promise<Market> {
+  return apiFetch<Market>(`/api/markets/${market_id}`);
+}
+
+/** GET /api/markets/:market_id/bets — all bets for a market */
+export async function fetchBetsByMarket(market_id: string): Promise<Bet[]> {
+  return apiFetch<Bet[]>(`/api/markets/${market_id}/bets`);
+}
+
+/** GET /api/portfolio/:address — full portfolio for a wallet address */
+export async function fetchPortfolio(address: string): Promise<Portfolio> {
+  return apiFetch<Portfolio>(`/api/portfolio/${address}`);
+}
+
+/** GET /api/markets/:market_id/stats — aggregate market statistics */
+export async function fetchMarketStats(market_id: string): Promise<MarketStats> {
+  return apiFetch<MarketStats>(`/api/markets/${market_id}/stats`);
+}
+
+/** GET /api/markets/:market_id/odds — live odds for a market */
+export async function fetchOdds(market_id: string): Promise<MarketOdds> {
+  return apiFetch<MarketOdds>(`/api/markets/${market_id}/odds`);
+}
+
+/** GET /api/stats — platform-wide statistics */
+export async function fetchPlatformStats(): Promise<PlatformStats> {
+  return apiFetch<PlatformStats>(`/api/stats`);
+}

--- a/frontend/lib/freighter.ts
+++ b/frontend/lib/freighter.ts
@@ -1,0 +1,72 @@
+// ============================================================
+// BOXMEOUT — Freighter Wallet Utilities (lib)
+// Low-level helpers for Freighter browser extension integration.
+// Works on Stellar Testnet and Mainnet (from NEXT_PUBLIC_STELLAR_NETWORK).
+// ============================================================
+
+import { Networks } from '@stellar/stellar-sdk';
+
+const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK ?? 'testnet';
+
+export const NETWORK_PASSPHRASE =
+  NETWORK === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET;
+
+// ─── Error ────────────────────────────────────────────────────────────────────
+
+export class FreighterNotInstalledError extends Error {
+  constructor() {
+    super('Freighter is not installed. Get it at https://freighter.app');
+    this.name = 'FreighterNotInstalledError';
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function getFreighter(): any {
+  if (typeof window === 'undefined') return null;
+  return (window as any).freighter ?? null;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Returns true if the Freighter extension is present in the browser.
+ * Safe to call server-side (returns false).
+ */
+export function isFreighterAvailable(): boolean {
+  return getFreighter() !== null;
+}
+
+/**
+ * Requests wallet access and returns the user's public key.
+ * Throws FreighterNotInstalledError if the extension is not present.
+ * Throws if the user rejects the connection request.
+ */
+export async function connectFreighter(): Promise<string> {
+  const freighter = getFreighter();
+  if (!freighter) throw new FreighterNotInstalledError();
+
+  await freighter.requestAccess();
+  const { publicKey } = await freighter.getPublicKey();
+  return publicKey;
+}
+
+/**
+ * Signs a transaction XDR string with Freighter and returns the signed XDR.
+ * Throws FreighterNotInstalledError if the extension is not present.
+ * Throws if the user rejects signing.
+ *
+ * @param xdr - Base64-encoded transaction XDR to sign
+ * @returns Signed transaction XDR string
+ */
+export async function signTransaction(xdr: string): Promise<string> {
+  const freighter = getFreighter();
+  if (!freighter) throw new FreighterNotInstalledError();
+
+  const result = await freighter.signTransaction(xdr, {
+    networkPassphrase: NETWORK_PASSPHRASE,
+  });
+
+  // Freighter v2+ returns { signedTxXdr }, older versions return the string directly
+  return typeof result === 'string' ? result : result.signedTxXdr;
+}

--- a/frontend/src/hooks/useMarketOdds.ts
+++ b/frontend/src/hooks/useMarketOdds.ts
@@ -1,0 +1,46 @@
+// ============================================================
+// BOXMEOUT — useMarketOdds Hook
+// Auto-refreshing odds hook backed by TanStack Query.
+// Refetches every 5 seconds; stops when market is Resolved or Cancelled.
+// ============================================================
+
+import { useQuery } from '@tanstack/react-query';
+import { fetchOdds, type MarketOdds } from '../../lib/api';
+import type { MarketStatus } from '../types';
+
+const REFETCH_INTERVAL_MS = 5_000;
+
+/** Statuses where live odds are no longer meaningful */
+const TERMINAL_STATUSES: MarketStatus[] = ['resolved', 'cancelled'];
+
+export interface UseMarketOddsResult {
+  odds: MarketOdds | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Fetches and auto-refreshes odds for a market.
+ *
+ * @param marketId - The market to watch
+ * @param status   - Current market status (stops polling when resolved/cancelled)
+ */
+export function useMarketOdds(
+  marketId: string,
+  status?: MarketStatus,
+): UseMarketOddsResult {
+  const isTerminal = status != null && TERMINAL_STATUSES.includes(status);
+
+  const { data, isLoading, error } = useQuery<MarketOdds, Error>({
+    queryKey: ['odds', marketId],
+    queryFn: () => fetchOdds(marketId),
+    refetchInterval: isTerminal ? false : REFETCH_INTERVAL_MS,
+    enabled: Boolean(marketId),
+  });
+
+  return {
+    odds: data ?? null,
+    isLoading,
+    error: error ?? null,
+  };
+}

--- a/frontend/src/hooks/useProjectedPayout.ts
+++ b/frontend/src/hooks/useProjectedPayout.ts
@@ -1,0 +1,59 @@
+// ============================================================
+// BOXMEOUT — useProjectedPayout Hook
+// Pure client-side parimutuel payout preview.
+// No API call — recalculates on market, outcome, or amount change.
+// ============================================================
+
+import { useMemo } from 'react';
+import type { BetSide, Market } from '../types';
+
+/**
+ * Calculates the projected payout for a bet using the parimutuel formula:
+ *
+ *   payout = (amount / side_pool_after) * total_pool_after * (1 - fee_bps / 10_000)
+ *
+ * where side_pool_after and total_pool_after include the user's bet amount.
+ *
+ * @param market  - The market to bet on (provides pool sizes and fee)
+ * @param side    - Which outcome the user is betting on
+ * @param amount  - Bet amount in XLM (as a number)
+ * @returns Projected payout in XLM, or null if any input is missing/invalid
+ */
+export function useProjectedPayout(
+  market: Market | null | undefined,
+  side: BetSide | null | undefined,
+  amount: number | null | undefined,
+): number | null {
+  return useMemo(() => {
+    if (!market || !side || amount == null || amount <= 0) return null;
+
+    // Convert XLM to stroops for integer arithmetic
+    const STROOPS = 10_000_000n;
+    const amountStroops = BigInt(Math.round(amount * 10_000_000));
+
+    const poolA = BigInt(market.pool_a);
+    const poolB = BigInt(market.pool_b);
+    const poolDraw = BigInt(market.pool_draw);
+
+    // Side pool before this bet
+    const sidePoolBefore =
+      side === 'fighter_a' ? poolA : side === 'fighter_b' ? poolB : poolDraw;
+
+    // Pools after including this bet
+    const sidePoolAfter = sidePoolBefore + amountStroops;
+    const totalPoolAfter = poolA + poolB + poolDraw + amountStroops;
+
+    // Zero-pool edge case: if side pool after is 0 (shouldn't happen since we add amount)
+    if (sidePoolAfter === 0n) return null;
+
+    // fee_bps is in basis points (0–10000); scale factor = 10000 - fee_bps
+    const feeFactor = BigInt(10_000 - market.fee_bps);
+
+    // payout_stroops = (amountStroops * totalPoolAfter * feeFactor) / (sidePoolAfter * 10_000)
+    const payoutStroops =
+      (amountStroops * totalPoolAfter * feeFactor) / (sidePoolAfter * 10_000n);
+
+    // Convert back to XLM
+    return Number(payoutStroops) / Number(STROOPS);
+  }, [market, side, amount]);
+}


### PR DESCRIPTION
- #788: frontend/lib/api.ts — APIError + 7 typed fetch functions (fetchMarkets, fetchMarketById, fetchBetsByMarket, fetchPortfolio, fetchMarketStats, fetchOdds, fetchPlatformStats)
- #789: frontend/lib/freighter.ts — isFreighterAvailable, connectFreighter, signTransaction; handles missing extension; testnet/mainnet via env
- #791: frontend/src/hooks/useProjectedPayout.ts — pure useMemo parimutuel payout preview; BigInt arithmetic; null on invalid/missing inputs
- #792: frontend/src/hooks/useMarketOdds.ts — TanStack Query v5; 5s refetch; stops polling on resolved/cancelled status
- .gitignore: add .claude/, .kiro/, .cursor/, .aider* entries
Closes #788 
Closes #789 
Closes #791 
Closes #792 

