### PR TITLE
[CONTRACTS] Implement fee_bps override per market in create_market()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+- `Market::get_bet()` — view function returning a bettor's position (#716)
+- `MarketFactory::get_open_market_ids()` — efficient open market filtering (#717)
+- `Market::upgrade()` — admin-only WASM upgrade mechanism (#718)
+- `create_market()` fee_bps override per market, capped at 1000 bps (#719)

--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -10,7 +10,7 @@
 mod tests;
 
 use soroban_sdk::{
-    contract, contractimpl, contractclient, token, Address, Env, Map, Vec,
+    contract, contractimpl, contractclient, token, Address, BytesN, Env, Map, Vec,
 };
 
 use boxmeout_shared::{
@@ -734,6 +734,15 @@ impl Market {
         Self::load_bets(&env, &bettor)
     }
 
+    /// Returns the bettor's first unclaimed bet position, or None if no bet exists.
+    pub fn get_bet(env: Env, bettor: Address) -> Option<BetRecord> {
+        let bets = Self::load_bets(&env, &bettor);
+        if bets.is_empty() {
+            return None;
+        }
+        Some(bets.get(0).unwrap())
+    }
+
     /// Returns the current odds for each outcome (in basis points).
     pub fn get_current_odds(env: Env) -> (u32, u32, u32) {
         let state = match Self::load_state(&env) {
@@ -892,6 +901,24 @@ impl Market {
             return Err(ContractError::Unauthorized);
         }
         env.storage().instance().set(&PAUSED, &false);
+        Ok(())
+    }
+
+    /// Upgrades the contract WASM. Only callable by the factory (admin).
+    ///
+    /// # Errors
+    /// - `Unauthorized`: Caller is not the factory admin
+    pub fn upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) -> Result<(), ContractError> {
+        admin.require_auth();
+        let factory: Address = env
+            .storage().persistent()
+            .get(&FACTORY)
+            .ok_or(ContractError::NotFactory)?;
+        if admin != factory {
+            return Err(ContractError::Unauthorized);
+        }
+        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+        boxmeout_shared::emit_contract_upgraded(&env, new_wasm_hash);
         Ok(())
     }
 }

--- a/contracts/market_factory/src/lib.rs
+++ b/contracts/market_factory/src/lib.rs
@@ -17,6 +17,7 @@ const ORACLE_WHITELIST: &str = "ORACLE_WHITELIST";
 const PAUSED: &str          = "PAUSED";
 const DEFAULT_CONFIG: &str  = "DEFAULT_CONFIG";
 const MARKET_WASM_HASH: &str = "MARKET_WASM_HASH";
+const OPEN_MARKETS: &str    = "OPEN_MARKETS";
 
 #[contractclient(name = "MarketClient")]
 pub trait MarketInterface {
@@ -91,6 +92,7 @@ impl MarketFactory {
         // Initialize with zero hash; admin must call update_market_wasm to set it
         let zero_hash: BytesN<32> = BytesN::from_array(&env, &[0u8; 32]);
         env.storage().persistent().set(&MARKET_WASM_HASH, &zero_hash);
+        env.storage().persistent().set(&OPEN_MARKETS, &Vec::<u64>::new(&env));
         Ok(())
     }
 
@@ -122,6 +124,7 @@ impl MarketFactory {
         caller: Address,
         fight: FightDetails,
         config: MarketConfig,
+        fee_bps: Option<u32>,
     ) -> Result<u64, ContractError> {
         // CHECKS — auth and pause guard first
         caller.require_auth();
@@ -136,9 +139,25 @@ impl MarketFactory {
         if config.min_bet == 0 {
             return Err(ContractError::BetTooSmall);
         }
-        if config.fee_bps > 1000 {
-            return Err(ContractError::Unauthorized);
-        }
+
+        // Resolve effective fee: use override if provided (capped at 1000 bps), else config value
+        let effective_fee_bps = match fee_bps {
+            Some(f) => {
+                if f > 1000 {
+                    return Err(ContractError::Unauthorized);
+                }
+                f
+            }
+            None => {
+                if config.fee_bps > 1000 {
+                    return Err(ContractError::Unauthorized);
+                }
+                config.fee_bps
+            }
+        };
+
+        let mut effective_config = config;
+        effective_config.fee_bps = effective_fee_bps;
 
         // EFFECTS — read current count (this becomes the new market_id)
         let market_id: u64 = env.storage().persistent().get(&MARKET_COUNT).unwrap_or(0);
@@ -168,7 +187,7 @@ impl MarketFactory {
             &env.current_contract_address(),
             &market_id,
             &fight.clone(),
-            &config,
+            &effective_config,
             &treasury,
         );
 
@@ -177,6 +196,12 @@ impl MarketFactory {
         market_map.set(market_id, market_address.clone());
         env.storage().persistent().set(&MARKET_MAP, &market_map);
         env.storage().persistent().set(&MARKET_COUNT, &new_count);
+
+        // Track as open market
+        let mut open_markets: Vec<u64> =
+            env.storage().persistent().get(&OPEN_MARKETS).unwrap_or_else(|| Vec::new(&env));
+        open_markets.push_back(market_id);
+        env.storage().persistent().set(&OPEN_MARKETS, &open_markets);
 
         boxmeout_shared::emit_market_created(&env, market_id, market_address, fight.match_id);
         Ok(market_id)
@@ -217,6 +242,50 @@ impl MarketFactory {
     /// Returns the total number of markets created.
     pub fn get_market_count(env: Env) -> u64 {
         env.storage().persistent().get(&MARKET_COUNT).unwrap_or(0)
+    }
+
+    /// Returns the IDs of all currently Open markets.
+    pub fn get_open_market_ids(env: Env) -> Vec<u64> {
+        env.storage().persistent().get(&OPEN_MARKETS).unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Removes a market from the open list when it is no longer Open.
+    /// Callable by admin or a whitelisted oracle after locking/resolving/cancelling.
+    ///
+    /// # Errors
+    /// - `Unauthorized`: Caller is not admin or whitelisted oracle
+    /// - `MarketNotFound`: Market ID does not exist
+    /// - `InvalidMarketStatus`: Market is still Open
+    pub fn remove_open_market(env: Env, caller: Address, market_id: u64) -> Result<(), ContractError> {
+        caller.require_auth();
+
+        let admin: Address = env.storage().persistent().get(&ADMIN).ok_or(ContractError::Unauthorized)?;
+        let oracles: Vec<Address> = env.storage().persistent().get(&ORACLE_WHITELIST).unwrap_or_else(|| Vec::new(&env));
+        if caller != admin && !oracles.contains(caller.clone()) {
+            return Err(ContractError::Unauthorized);
+        }
+
+        // Verify market is no longer Open
+        let market_map: Map<u64, Address> =
+            env.storage().persistent().get(&MARKET_MAP).unwrap_or_else(|| Map::new(&env));
+        let market_address = market_map.get(market_id).ok_or(ContractError::MarketNotFound)?;
+        let state = MarketClient::new(&env, &market_address)
+            .try_get_state()
+            .map_err(|_| ContractError::MarketNotFound)?
+            .map_err(|_| ContractError::MarketNotFound)?;
+        if state.status == MarketStatus::Open {
+            return Err(ContractError::InvalidMarketStatus);
+        }
+
+        let open: Vec<u64> = env.storage().persistent().get(&OPEN_MARKETS).unwrap_or_else(|| Vec::new(&env));
+        let mut updated: Vec<u64> = Vec::new(&env);
+        for id in open.iter() {
+            if id != market_id {
+                updated.push_back(id);
+            }
+        }
+        env.storage().persistent().set(&OPEN_MARKETS, &updated);
+        Ok(())
     }
 
     /// Adds an oracle to the whitelist.

--- a/contracts/shared/src/events.rs
+++ b/contracts/shared/src/events.rs
@@ -82,6 +82,11 @@ pub fn emit_conflicting_oracle_report(env: &Env, market_id: u64, oracle_address:
     env.events().publish(topics, oracle_address);
 }
 
+pub fn emit_contract_upgraded(env: &Env, new_wasm_hash: soroban_sdk::BytesN<32>) {
+    let topics = (Symbol::new(env, "contract_upgraded"),);
+    env.events().publish(topics, new_wasm_hash);
+}
+
 #[cfg(test)]
 mod tests {
     use soroban_sdk::{


### PR DESCRIPTION
closes #716 
closes #717  
closes #718 
closes #719 

## Closes

Closes #

## What this PR does

<!-- One paragraph. What did you implement? Do not explain how — the code does that. -->

## Testing

<!-- How did you verify this works? What test cases did you add? -->

## Screenshots (frontend changes only)

<!-- Add before/after screenshots or a short screen recording. -->

## Checklist

- [ ] I have read `docs/contributing.md`
- [ ] My code follows the naming conventions in the guidelines
- [ ] I have added or updated tests for my changes
- [ ] All tests pass locally (`cargo test` / `npm test`)
- [ ] Lint passes (`cargo clippy` / `npm run lint`)
- [ ] No `console.log` or `unwrap()` left in production paths
- [ ] No secrets committed
