### PR TITLE
feat: admin CSV export endpoints for regulatory compliance

### DIFF
--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -2,6 +2,14 @@ import { Router, Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { AppError } from '../utils/AppError';
 import { flagDispute, investigateDispute, cancelMarket, resolveDispute, listDisputes, processRefunds } from '../api/controllers/AdminController';
+import {
+  logExportAudit,
+  streamUsersExport,
+  streamTradesExport,
+  streamTreasuryExport,
+  buildTradesCsv,
+} from '../services/export.service';
+import { sendExportReadyEmail } from '../services/email.service';
 
 const router = Router();
 
@@ -78,6 +86,76 @@ router.post('/resolve-dispute/:market_id', requireAdmin, async (req: Request, re
 router.post('/cancel/:market_id', requireAdmin, async (req: Request, res: Response, next: NextFunction) => {
   try {
     await cancelMarket(req, res);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// CSV Export routes
+// ---------------------------------------------------------------------------
+
+router.get('/export/users', requireAdmin, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const adminId = (req as unknown as Record<string, unknown>).userId as string;
+    await logExportAudit(adminId, 'users');
+    await streamUsersExport(res);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/export/trades', requireAdmin, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const adminId = (req as unknown as Record<string, unknown>).userId as string;
+    const { from, to } = req.query as { from?: string; to?: string };
+    await logExportAudit(adminId, 'trades', { from, to });
+    await streamTradesExport(res, from, to);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get('/export/treasury', requireAdmin, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const adminId = (req as unknown as Record<string, unknown>).userId as string;
+    await logExportAudit(adminId, 'treasury');
+    await streamTreasuryExport(res);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * POST /api/admin/export/request
+ * Body: { type: 'trades', from?: string, to?: string, email: string }
+ *
+ * Kicks off an async export. Builds the CSV in the background and emails
+ * it as an attachment when ready.
+ */
+router.post('/export/request', requireAdmin, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const adminId = (req as unknown as Record<string, unknown>).userId as string;
+    const { type, from, to, email } = req.body as { type: string; from?: string; to?: string; email: string };
+
+    if (!email || typeof email !== 'string') throw new AppError(400, 'email is required');
+    if (type !== 'trades') throw new AppError(400, 'type must be "trades"');
+
+    await logExportAudit(adminId, `async:${type}`, { from, to, email });
+
+    // Respond immediately; build + send in background
+    res.status(202).json({ message: 'Export queued. You will receive an email when ready.' });
+
+    setImmediate(async () => {
+      try {
+        const csv = await buildTradesCsv(from, to);
+        await sendExportReadyEmail(email, type, csv);
+      } catch (err) {
+        // Background failure — already responded 202, just log
+        const { logger } = await import('../utils/logger');
+        logger.error({ msg: 'Async export failed', err });
+      }
+    });
   } catch (err) {
     next(err);
   }

--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -92,3 +92,25 @@ export async function sendPasswordResetEmail(
     logger.error({ msg: 'Failed to send password reset email', error: err });
   }
 }
+
+/**
+ * Send an async export-ready email with the CSV as an attachment.
+ */
+export async function sendExportReadyEmail(
+  toEmail: string,
+  exportType: string,
+  csvContent: string,
+): Promise<void> {
+  const filename = `${exportType}-export-${new Date().toISOString().slice(0, 10)}.csv`;
+  try {
+    await transporter.sendMail({
+      from: `"${APP_NAME}" <${FROM_ADDRESS}>`,
+      to: toEmail,
+      subject: `[${APP_NAME}] Your ${exportType} export is ready`,
+      text: `Your requested ${exportType} export is attached as ${filename}.`,
+      attachments: [{ filename, content: csvContent, contentType: 'text/csv' }],
+    });
+  } catch (err) {
+    logger.error({ msg: 'Failed to send export ready email', error: err });
+  }
+}

--- a/backend/src/services/export.service.ts
+++ b/backend/src/services/export.service.ts
@@ -1,0 +1,160 @@
+import type { Response } from 'express';
+import { pool } from '../config/db';
+import { logger } from '../utils/logger';
+
+const FETCH_SIZE = 500;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function csvRow(values: unknown[]): string {
+  return values.map((v) => {
+    const s = v == null ? '' : String(v);
+    return /[,"\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  }).join(',') + '\n';
+}
+
+function startCsvStream(res: Response, filename: string): void {
+  res.setHeader('Content-Type', 'text/csv');
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+  res.setHeader('Transfer-Encoding', 'chunked');
+  res.flushHeaders();
+}
+
+// ---------------------------------------------------------------------------
+// Audit log
+// ---------------------------------------------------------------------------
+
+export async function logExportAudit(
+  adminId: string,
+  exportType: string,
+  params: Record<string, unknown> = {},
+): Promise<void> {
+  try {
+    await pool.query(
+      `INSERT INTO admin_audit_log (admin_id, action, details, created_at)
+       VALUES ($1, $2, $3, NOW())`,
+      [adminId, `export:${exportType}`, JSON.stringify(params)],
+    );
+  } catch {
+    logger.warn({ msg: 'audit log insert skipped (table may not exist)', exportType });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core: stream SQL via server-side cursor in batches → res
+// ---------------------------------------------------------------------------
+
+async function pipeQueryToCsv(
+  res: Response,
+  sql: string,
+  values: unknown[],
+  header: string,
+  rowMapper: (row: Record<string, unknown>) => string,
+): Promise<void> {
+  const client = await pool.connect();
+  try {
+    res.write(header);
+    await client.query('BEGIN');
+    await client.query(`DECLARE export_cursor NO SCROLL CURSOR FOR ${sql}`, values);
+
+    while (true) {
+      const { rows } = await client.query(`FETCH ${FETCH_SIZE} FROM export_cursor`);
+      if (rows.length === 0) break;
+      const chunk = rows.map(rowMapper).join('');
+      const ok = res.write(chunk);
+      if (!ok) await new Promise<void>((r) => res.once('drain', r));
+    }
+
+    await client.query('CLOSE export_cursor');
+    await client.query('COMMIT');
+    res.end();
+  } catch (err) {
+    logger.error({ msg: 'CSV stream error', err });
+    try { await client.query('ROLLBACK'); } catch { /* ignore */ }
+    if (!res.writableEnded) res.end();
+  } finally {
+    client.release();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Streaming exports
+// ---------------------------------------------------------------------------
+
+export async function streamUsersExport(res: Response): Promise<void> {
+  startCsvStream(res, 'users.csv');
+  await pipeQueryToCsv(
+    res,
+    `SELECT bettor_address AS wallet_address,
+            MIN(placed_at)  AS first_bet_at,
+            COUNT(*)        AS total_bets,
+            SUM(amount)     AS total_wagered
+     FROM bets
+     GROUP BY bettor_address
+     ORDER BY first_bet_at`,
+    [],
+    csvRow(['wallet_address', 'first_bet_at', 'total_bets', 'total_wagered']),
+    (r) => csvRow([r.wallet_address, r.first_bet_at, r.total_bets, r.total_wagered]),
+  );
+}
+
+export async function streamTradesExport(
+  res: Response,
+  from?: string,
+  to?: string,
+): Promise<void> {
+  startCsvStream(res, 'trades.csv');
+  const conds: string[] = [];
+  const vals: unknown[] = [];
+  if (from) conds.push(`placed_at >= $${vals.push(from)}`);
+  if (to)   conds.push(`placed_at <= $${vals.push(to)}`);
+  const where = conds.length ? `WHERE ${conds.join(' AND ')}` : '';
+
+  await pipeQueryToCsv(
+    res,
+    `SELECT id, market_id, bettor_address, side, amount, placed_at, claimed, payout, tx_hash
+     FROM bets ${where} ORDER BY placed_at`,
+    vals,
+    csvRow(['id', 'market_id', 'bettor_address', 'side', 'amount', 'placed_at', 'claimed', 'payout', 'tx_hash']),
+    (r) => csvRow([r.id, r.market_id, r.bettor_address, r.side, r.amount, r.placed_at, r.claimed, r.payout, r.tx_hash]),
+  );
+}
+
+export async function streamTreasuryExport(res: Response): Promise<void> {
+  startCsvStream(res, 'treasury.csv');
+  await pipeQueryToCsv(
+    res,
+    `SELECT id, contract_address, event_type, ledger_sequence, ledger_close_time, tx_hash, payload
+     FROM blockchain_events
+     WHERE event_type ILIKE '%fee%' OR event_type ILIKE '%treasury%'
+     ORDER BY ledger_close_time`,
+    [],
+    csvRow(['id', 'contract_address', 'event_type', 'ledger_sequence', 'ledger_close_time', 'tx_hash', 'payload']),
+    (r) => csvRow([r.id, r.contract_address, r.event_type, r.ledger_sequence, r.ledger_close_time, r.tx_hash, JSON.stringify(r.payload)]),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Async (buffered) export — builds full CSV string for email attachment
+// ---------------------------------------------------------------------------
+
+export async function buildTradesCsv(from?: string, to?: string): Promise<string> {
+  const conds: string[] = [];
+  const vals: unknown[] = [];
+  if (from) conds.push(`placed_at >= $${vals.push(from)}`);
+  if (to)   conds.push(`placed_at <= $${vals.push(to)}`);
+  const where = conds.length ? `WHERE ${conds.join(' AND ')}` : '';
+
+  const { rows } = await pool.query(
+    `SELECT id, market_id, bettor_address, side, amount, placed_at, claimed, payout, tx_hash
+     FROM bets ${where} ORDER BY placed_at`,
+    vals,
+  );
+
+  return (
+    csvRow(['id', 'market_id', 'bettor_address', 'side', 'amount', 'placed_at', 'claimed', 'payout', 'tx_hash']) +
+    rows.map((r) => csvRow([r.id, r.market_id, r.bettor_address, r.side, r.amount, r.placed_at, r.claimed, r.payout, r.tx_hash])).join('')
+  );
+}


### PR DESCRIPTION
closes #459



## Summary
Implements streamed CSV exports for admin regulatory reporting.

## Endpoints
- `GET /api/admin/export/users` — unique bettors (wallet_address, first_bet_at, total_bets, total_wagered)
- `GET /api/admin/export/trades?from=&to=` — all bets with optional ISO date range filter
- `GET /api/admin/export/treasury` — fee/treasury blockchain events
- `POST /api/admin/export/request` — async export; responds 202 and emails CSV as attachment when ready

## Implementation details
- **Streaming**: uses PostgreSQL `DECLARE CURSOR` + `FETCH 500` batches — no full result buffering, back-pressure aware
- **Auth**: all routes protected by existing `requireAdmin` middleware
- **Audit log**: each export inserts a row into `admin_audit_log` (non-blocking if table absent)
- **Async email**: `sendExportReadyEmail` added to `email.service.ts`, attaches CSV via nodemailer

## Files changed
- `backend/src/services/export.service.ts` (new)
- `backend/src/routes/admin.routes.ts` (modified)
- `backend/src/services/email.service.ts` (modified)

## Migration required
```sql
CREATE TABLE admin_audit_log (
  id SERIAL PRIMARY KEY,
  admin_id TEXT NOT NULL,
  action TEXT NOT NULL,
  details JSONB DEFAULT '{}',
  created_at TIMESTAMPTZ DEFAULT NOW()
);
```