### PR TITLE
feat: market filter bar on Home page (status tabs + weight class dropdown)

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,8 +1,10 @@
-/**
- * Home page — server component.
- * Fetches active markets on the server and passes them to MarketList.
- * Shows three tabs: Active, Upcoming, Resolved.
- */
-export default async function HomePage(): Promise<JSX.Element> {
-  throw new Error("Not implemented");
+import { Suspense } from "react";
+import { HomeContent } from "@/components/HomeContent";
+
+export default function HomePage(): JSX.Element {
+  return (
+    <Suspense>
+      <HomeContent />
+    </Suspense>
+  );
 }

--- a/frontend/components/HomeContent.tsx
+++ b/frontend/components/HomeContent.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useCallback, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useMarkets } from "@/hooks/useMarkets";
+import { MarketFilterBar, STATUS_TABS, StatusTab } from "@/components/MarketFilterBar";
+import { MarketList } from "@/components/MarketList";
+import { MarketStatus } from "@/lib/api";
+
+function parseStatusTab(value: string | null): StatusTab {
+  if (STATUS_TABS.includes(value as StatusTab)) return value as StatusTab;
+  return "All";
+}
+
+export function HomeContent(): JSX.Element {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const statusTab = parseStatusTab(searchParams.get("status"));
+  const weightClass = searchParams.get("weightClass") ?? "";
+
+  const filters = useMemo(
+    () => ({
+      ...(statusTab !== "All" ? { status: statusTab as MarketStatus } : {}),
+      ...(weightClass ? { weightClass } : {}),
+    }),
+    [statusTab, weightClass]
+  );
+
+  const { markets, isLoading } = useMarkets(filters);
+
+  const weightClasses = useMemo(() => {
+    const seen = new Set<string>();
+    for (const m of markets) {
+      seen.add(m.fighterA.weightClass);
+      seen.add(m.fighterB.weightClass);
+    }
+    return Array.from(seen).sort();
+  }, [markets]);
+
+  const updateURL = useCallback(
+    (nextStatus: StatusTab, nextWeightClass: string) => {
+      const params = new URLSearchParams();
+      if (nextStatus !== "All") params.set("status", nextStatus);
+      if (nextWeightClass) params.set("weightClass", nextWeightClass);
+      const qs = params.toString();
+      router.push(qs ? `/?${qs}` : "/");
+    },
+    [router]
+  );
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">Markets</h1>
+      <MarketFilterBar
+        statusTab={statusTab}
+        weightClass={weightClass}
+        weightClasses={weightClasses}
+        onStatusChange={(s) => updateURL(s, weightClass)}
+        onWeightClassChange={(wc) => updateURL(statusTab, wc)}
+      />
+      <MarketList markets={markets} isLoading={isLoading} />
+    </main>
+  );
+}

--- a/frontend/components/MarketFilterBar.tsx
+++ b/frontend/components/MarketFilterBar.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+export const STATUS_TABS = ["All", "Open", "Locked", "Resolved"] as const;
+export type StatusTab = (typeof STATUS_TABS)[number];
+
+export interface MarketFilterBarProps {
+  statusTab: StatusTab;
+  weightClass: string;
+  weightClasses: string[];
+  onStatusChange: (status: StatusTab) => void;
+  onWeightClassChange: (weightClass: string) => void;
+}
+
+export function MarketFilterBar({
+  statusTab,
+  weightClass,
+  weightClasses,
+  onStatusChange,
+  onWeightClassChange,
+}: MarketFilterBarProps): JSX.Element {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-6">
+      <div className="flex gap-1 rounded-lg bg-gray-100 p-1">
+        {STATUS_TABS.map((tab) => (
+          <button
+            key={tab}
+            onClick={() => onStatusChange(tab)}
+            className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+              statusTab === tab
+                ? "bg-white text-gray-900 shadow-sm"
+                : "text-gray-600 hover:text-gray-900"
+            }`}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+
+      <select
+        value={weightClass}
+        onChange={(e) => onWeightClassChange(e.target.value)}
+        className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+      >
+        <option value="">All Weight Classes</option>
+        {weightClasses.map((wc) => (
+          <option key={wc} value={wc}>
+            {wc}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -65,9 +65,12 @@ export interface PortfolioSummary {
   roi: number;
 }
 
-export interface MarketQueryParams {
+export interface MarketFilters {
   status?: MarketStatus;
   weightClass?: string;
+}
+
+export interface MarketQueryParams extends MarketFilters {
   page?: number;
   limit?: number;
 }


### PR DESCRIPTION
## Summary
- Adds `MarketFilterBar` component with **status tabs** (`All / Open / Locked / Resolved`) and a **weight class `<select>`** dropdown populated from distinct weight classes in fetched markets
- Adds `HomeContent` client component that reads `?status=` and `?weightClass=` query params on load, passes derived filters to `useMarkets()`, and syncs URL on every filter change via `router.push()`
- Wraps `HomeContent` in `<Suspense>` inside `app/page.tsx` (required by Next.js 14 for `useSearchParams`)
- Adds `MarketFilters` interface to `lib/api.ts` (was imported by `useMarkets.ts` but missing); `MarketQueryParams` now extends it

## Files changed
| File | Change |
|------|--------|
| `frontend/lib/api.ts` | Add `MarketFilters` export; `MarketQueryParams` extends it |
| `frontend/components/MarketFilterBar.tsx` | New — status tabs + weight class dropdown |
| `frontend/components/HomeContent.tsx` | New — client component with URL filter state |
| `frontend/app/page.tsx` | Replace stub; server component wrapping `HomeContent` in Suspense |

## Test plan
- [ ] Visit `/` — All tab selected, no weight class filter, all markets shown
- [ ] Click `Open` tab — URL updates to `/?status=Open`, market list updates
- [ ] Select a weight class — URL updates to `/?status=Open&weightClass=Heavyweight`
- [ ] Visit `/?status=Open` directly — Open tab pre-selected on load
- [ ] Visit `/?status=Locked&weightClass=Middleweight` — both filters pre-selected
- [ ] Click `All` tab — URL clears to `/`, all markets shown
- [ ] Weight class dropdown shows only classes present in fetched markets

closes #952 