### PR TITLE
feat: implement API client, home page, and market detail (#949, #945, #946)

### DIFF
--- a/frontend/__tests__/api.test.ts
+++ b/frontend/__tests__/api.test.ts
@@ -1,0 +1,231 @@
+import {
+  fetchMarkets,
+  fetchMarketById,
+  fetchMarketStats,
+  fetchMarketBets,
+  fetchBetsByAddress,
+  fetchPortfolioSummary,
+  fetchPayoutEstimate,
+  fetchOddsHistory,
+  ApiError,
+  Market,
+  Bet,
+  MarketStats,
+  OddsSnapshot,
+  PortfolioSummary,
+} from "@/lib/api";
+
+const MARKET: Market = {
+  id: "mkt-1",
+  contractAddress: "CA1",
+  fighterA: { name: "Ali", record: "20-0", nationality: "USA", weightClass: "Heavyweight" },
+  fighterB: { name: "Foreman", record: "18-2", nationality: "USA", weightClass: "Heavyweight" },
+  scheduledAt: "2026-07-01T20:00:00Z",
+  bettingEndsAt: "2026-07-01T19:00:00Z",
+  status: "Open",
+  outcome: null,
+  poolA: "1000000000",
+  poolB: "500000000",
+  totalPool: "1500000000",
+  oracleAddress: "GORACLE",
+  createdBy: "GCREATOR",
+};
+
+const BET: Bet = {
+  id: "bet-1",
+  marketId: "mkt-1",
+  bettor: "GADDR1",
+  side: "FighterA",
+  amount: "100000000",
+  placedAt: "2026-06-20T10:00:00Z",
+  claimed: false,
+  payout: null,
+};
+
+const STATS: MarketStats = {
+  totalBets: 10,
+  uniqueBettors: 5,
+  poolA: "1000000000",
+  poolB: "500000000",
+  totalVolume: "1500000000",
+  impliedOddsA: 66.7,
+  impliedOddsB: 33.3,
+};
+
+const SNAPSHOT: OddsSnapshot = {
+  timestamp: "2026-06-20T10:00:00Z",
+  poolA: "1000000000",
+  poolB: "500000000",
+  oddsA: 66.7,
+  oddsB: 33.3,
+};
+
+const SUMMARY: PortfolioSummary = {
+  totalStaked: "100000000",
+  totalWinnings: "0",
+  pendingClaims: "0",
+  activeBets: 1,
+  completedBets: 0,
+  roi: 0,
+};
+
+function mockOk(body: unknown) {
+  return jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(""),
+  });
+}
+
+function mockError(status: number, message = "Server error") {
+  return jest.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ message }),
+    text: () => Promise.resolve(message),
+  });
+}
+
+afterEach(() => jest.restoreAllMocks());
+
+// ─── fetchMarkets ─────────────────────────────────────────────────────────────
+
+test("fetchMarkets: returns market array", async () => {
+  global.fetch = mockOk([MARKET]);
+  const result = await fetchMarkets();
+  expect(result).toEqual([MARKET]);
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining("/api/markets"),
+    expect.any(Object)
+  );
+});
+
+test("fetchMarkets: passes query params", async () => {
+  global.fetch = mockOk([MARKET]);
+  await fetchMarkets({ status: "Open", weightClass: "Heavyweight", page: 2, limit: 10 });
+  const url = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+  expect(url).toContain("status=Open");
+  expect(url).toContain("weightClass=Heavyweight");
+  expect(url).toContain("page=2");
+  expect(url).toContain("limit=10");
+});
+
+test("fetchMarkets: throws ApiError on 500", async () => {
+  global.fetch = mockError(500);
+  await expect(fetchMarkets()).rejects.toBeInstanceOf(ApiError);
+  await expect(fetchMarkets()).rejects.toMatchObject({ status: 500 });
+});
+
+// ─── fetchMarketById ──────────────────────────────────────────────────────────
+
+test("fetchMarketById: returns market", async () => {
+  global.fetch = mockOk(MARKET);
+  const result = await fetchMarketById("mkt-1");
+  expect(result).toEqual(MARKET);
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining("/api/markets/mkt-1"),
+    expect.any(Object)
+  );
+});
+
+test("fetchMarketById: throws ApiError with status 404", async () => {
+  global.fetch = mockError(404, "Not found");
+  const err = await fetchMarketById("missing").catch((e) => e);
+  expect(err).toBeInstanceOf(ApiError);
+  expect(err.status).toBe(404);
+  expect(err.message).toBe("Not found");
+});
+
+// ─── fetchMarketStats ─────────────────────────────────────────────────────────
+
+test("fetchMarketStats: returns stats", async () => {
+  global.fetch = mockOk(STATS);
+  const result = await fetchMarketStats("mkt-1");
+  expect(result).toEqual(STATS);
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining("/api/markets/mkt-1/stats"),
+    expect.any(Object)
+  );
+});
+
+// ─── fetchMarketBets ──────────────────────────────────────────────────────────
+
+test("fetchMarketBets: returns bets array", async () => {
+  global.fetch = mockOk([BET]);
+  const result = await fetchMarketBets("mkt-1");
+  expect(result).toEqual([BET]);
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining("/api/markets/mkt-1/bets"),
+    expect.any(Object)
+  );
+});
+
+// ─── fetchBetsByAddress ───────────────────────────────────────────────────────
+
+test("fetchBetsByAddress: returns bets for address", async () => {
+  global.fetch = mockOk([BET]);
+  const result = await fetchBetsByAddress("GADDR1");
+  expect(result).toEqual([BET]);
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining("/api/bets/GADDR1"),
+    expect.any(Object)
+  );
+});
+
+// ─── fetchPortfolioSummary ────────────────────────────────────────────────────
+
+test("fetchPortfolioSummary: returns summary", async () => {
+  global.fetch = mockOk(SUMMARY);
+  const result = await fetchPortfolioSummary("GADDR1");
+  expect(result).toEqual(SUMMARY);
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining("/api/bets/GADDR1/portfolio"),
+    expect.any(Object)
+  );
+});
+
+// ─── fetchPayoutEstimate ──────────────────────────────────────────────────────
+
+test("fetchPayoutEstimate: returns BigInt from string estimate", async () => {
+  global.fetch = mockOk({ estimate: "150000000" });
+  const result = await fetchPayoutEstimate("mkt-1", "FighterA", BigInt(100000000));
+  expect(result).toBe(BigInt(150000000));
+  expect(typeof result).toBe("bigint");
+});
+
+test("fetchPayoutEstimate: passes correct query params", async () => {
+  global.fetch = mockOk({ estimate: "0" });
+  await fetchPayoutEstimate("mkt-1", "FighterB", BigInt(50000000));
+  const url = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+  expect(url).toContain("market_id=mkt-1");
+  expect(url).toContain("side=FighterB");
+  expect(url).toContain("amount=50000000");
+});
+
+test("fetchPayoutEstimate: throws ApiError on non-2xx", async () => {
+  global.fetch = mockError(400, "Bad request");
+  await expect(fetchPayoutEstimate("mkt-1", "FighterA", BigInt(1))).rejects.toBeInstanceOf(ApiError);
+});
+
+// ─── fetchOddsHistory ─────────────────────────────────────────────────────────
+
+test("fetchOddsHistory: returns snapshots array", async () => {
+  global.fetch = mockOk([SNAPSHOT]);
+  const result = await fetchOddsHistory("mkt-1");
+  expect(result).toEqual([SNAPSHOT]);
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining("/api/markets/mkt-1/odds-history"),
+    expect.any(Object)
+  );
+});
+
+// ─── ApiError ────────────────────────────────────────────────────────────────
+
+test("ApiError: has correct name and status", () => {
+  const err = new ApiError(422, "Unprocessable");
+  expect(err.name).toBe("ApiError");
+  expect(err.status).toBe(422);
+  expect(err.message).toBe("Unprocessable");
+  expect(err).toBeInstanceOf(Error);
+});

--- a/frontend/app/markets/[id]/page.tsx
+++ b/frontend/app/markets/[id]/page.tsx
@@ -1,76 +1,28 @@
-import { FighterCard } from "@/components/FighterCard";
-import { BettingInterface } from "@/components/BettingInterface";
-import { MarketOddsBar } from "@/components/MarketOddsBar";
-import { MarketOddsChart } from "@/components/MarketOddsChart";
-import { MarketStatusBadge } from "@/components/MarketStatusBadge";
-import { CountdownTimer } from "@/components/CountdownTimer";
-import { Market } from "@/lib/api";
+import { fetchMarketById, fetchMarketBets, fetchOddsHistory } from "@/lib/api";
+import { MarketDetailClient } from "@/components/MarketDetailClient";
+import { notFound } from "next/navigation";
 
 interface Props {
   params: { id: string };
 }
 
-/** Placeholder market for layout rendering until API is wired up. */
-function placeholderMarket(id: string): Market {
-  return {
-    id,
-    contractAddress: "",
-    fighterA: { name: "Fighter A", record: "20-0", nationality: "USA", weightClass: "Heavyweight" },
-    fighterB: { name: "Fighter B", record: "18-2", nationality: "UK", weightClass: "Heavyweight" },
-    scheduledAt: new Date(Date.now() + 86400000).toISOString(),
-    bettingEndsAt: new Date(Date.now() + 43200000).toISOString(),
-    status: "Open",
-    outcome: null,
-    poolA: "0",
-    poolB: "0",
-    totalPool: "0",
-    oracleAddress: "",
-    createdBy: "",
-  };
-}
-
 export default async function MarketDetailPage({ params }: Props): Promise<JSX.Element> {
-  const market = placeholderMarket(params.id);
-  const poolA = BigInt(market.poolA);
-  const poolB = BigInt(market.poolB);
-  const total = poolA + poolB;
-  const oddsA = total === BigInt(0) ? 50 : Number((poolA * BigInt(100)) / total);
-  const oddsB = 100 - oddsA;
+  const [market, bets, oddsHistory] = await Promise.all([
+    fetchMarketById(params.id).catch(() => null),
+    fetchMarketBets(params.id).catch(() => []),
+    fetchOddsHistory(params.id).catch(() => []),
+  ]);
+
+  if (!market) notFound();
 
   return (
-    <div className="space-y-5">
-      {/* Header */}
-      <div className="flex flex-wrap items-center gap-3">
-        <h1 className="text-xl font-bold text-white">
-          {market.fighterA.name} vs {market.fighterB.name}
-        </h1>
-        <MarketStatusBadge status={market.status} />
-      </div>
-
-      <CountdownTimer
-        targetTimestamp={Math.floor(new Date(market.bettingEndsAt).getTime() / 1000)}
-        label="Betting closes in"
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <MarketDetailClient
+        marketId={params.id}
+        initialMarket={market}
+        initialBets={bets}
+        initialOddsHistory={oddsHistory}
       />
-
-      {/* Fighter cards — stack on mobile, side-by-side on md+ */}
-      <div className="flex flex-col md:flex-row gap-4">
-        <FighterCard fighter={market.fighterA} side="A" poolAmount={poolA} impliedOdds={oddsA} />
-        <FighterCard fighter={market.fighterB} side="B" poolAmount={poolB} impliedOdds={oddsB} />
-      </div>
-
-      {/* Odds bar */}
-      <MarketOddsBar
-        poolA={poolA}
-        poolB={poolB}
-        fighterAName={market.fighterA.name}
-        fighterBName={market.fighterB.name}
-      />
-
-      {/* Chart — full width */}
-      <MarketOddsChart marketId={market.id} historicalOdds={[]} />
-
-      {/* Betting interface — full width below chart */}
-      <BettingInterface market={market} onBetPlaced={() => {}} />
     </div>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,10 +1,11 @@
-import { Suspense } from "react";
-import { HomeContent } from "@/components/HomeContent";
+import { fetchMarkets } from "@/lib/api";
+import { HomePageContent } from "@/components/HomePageContent";
 
-export default function HomePage(): JSX.Element {
-  return (
-    <Suspense>
-      <HomeContent />
-    </Suspense>
-  );
+export const revalidate = 30; // ISR: revalidate every 30s
+
+export default async function HomePage(): Promise<JSX.Element> {
+  // Server-side fetch for faster first paint (no loading flash)
+  const initialMarkets = await fetchMarkets().catch(() => []);
+
+  return <HomePageContent initialMarkets={initialMarkets} />;
 }

--- a/frontend/components/HomePageContent.tsx
+++ b/frontend/components/HomePageContent.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useState } from "react";
+import { Market } from "@/lib/api";
+import { MarketList } from "@/components/MarketList";
+
+type HomeTab = "Active" | "Upcoming" | "Resolved";
+const TABS: HomeTab[] = ["Active", "Upcoming", "Resolved"];
+
+function filterMarkets(markets: Market[], tab: HomeTab): Market[] {
+  switch (tab) {
+    case "Active":
+      return markets.filter((m) => m.status === "Open" || m.status === "Locked");
+    case "Upcoming":
+      return markets.filter((m) => m.status === "Open");
+    case "Resolved":
+      return markets.filter((m) => m.status === "Resolved");
+  }
+}
+
+export interface HomePageContentProps {
+  initialMarkets: Market[];
+}
+
+export function HomePageContent({ initialMarkets }: HomePageContentProps): JSX.Element {
+  const [tab, setTab] = useState<HomeTab>("Active");
+
+  const filtered = filterMarkets(initialMarkets, tab);
+
+  return (
+    <main className="container mx-auto px-4 py-8">
+      {/* Hero */}
+      <section className="mb-10 text-center">
+        <h1 className="text-4xl md:text-5xl font-extrabold text-white tracking-tight mb-3">
+          BOXMEOUT - Bet on Boxing
+        </h1>
+        <p className="text-gray-400 text-lg max-w-xl mx-auto">
+          Decentralized prediction markets for boxing. Place XLM bets on-chain — no middlemen,
+          no custody.
+        </p>
+      </section>
+
+      {/* Tab bar */}
+      <div className="flex gap-1 rounded-lg bg-gray-800 p-1 w-fit mb-6" role="tablist">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            role="tab"
+            aria-selected={tab === t}
+            onClick={() => setTab(t)}
+            className={`px-5 py-2 rounded-md text-sm font-medium transition-colors ${
+              tab === t
+                ? "bg-amber-500 text-black shadow-sm"
+                : "text-gray-400 hover:text-white"
+            }`}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      <MarketList markets={filtered} isLoading={false} />
+    </main>
+  );
+}

--- a/frontend/components/MarketDetailClient.tsx
+++ b/frontend/components/MarketDetailClient.tsx
@@ -1,0 +1,135 @@
+"use client";
+import { useState } from "react";
+import { useMarket } from "@/hooks/useMarket";
+import { Market, Bet } from "@/lib/api";
+import { FighterCard } from "@/components/FighterCard";
+import { BettingInterface } from "@/components/BettingInterface";
+import { MarketOddsBar } from "@/components/MarketOddsBar";
+import { MarketOddsChart } from "@/components/MarketOddsChart";
+import { MarketStatusBadge } from "@/components/MarketStatusBadge";
+import { CountdownTimer } from "@/components/CountdownTimer";
+import { DisputeModal } from "@/components/DisputeModal";
+
+const DISPUTE_WINDOW_SEC = 24 * 60 * 60; // 24 h
+
+function isInDisputeWindow(market: Market): boolean {
+  if (market.status !== "Resolved") return false;
+  // scheduledAt is the closest proxy for resolvedAt we have on the type
+  const resolvedAt = new Date(market.scheduledAt).getTime();
+  return Date.now() - resolvedAt < DISPUTE_WINDOW_SEC * 1000;
+}
+
+function BetHistoryRow({ bet }: { bet: Bet }): JSX.Element {
+  const xlm = (Number(BigInt(bet.amount)) / 1e7).toFixed(2);
+  return (
+    <tr className="border-b border-gray-700 text-sm">
+      <td className="py-2 pr-4 text-gray-300 font-mono text-xs truncate max-w-[120px]">{bet.bettor}</td>
+      <td className={`py-2 pr-4 font-medium ${bet.side === "FighterA" ? "text-blue-400" : "text-red-400"}`}>
+        {bet.side === "FighterA" ? "Fighter A" : "Fighter B"}
+      </td>
+      <td className="py-2 pr-4 text-white">{xlm} XLM</td>
+      <td className="py-2 text-gray-400 text-xs">{new Date(bet.placedAt).toLocaleString()}</td>
+    </tr>
+  );
+}
+
+export interface MarketDetailClientProps {
+  marketId: string;
+  initialMarket: Market;
+  initialBets: Bet[];
+  initialOddsHistory: import("@/lib/api").OddsSnapshot[];
+}
+
+export function MarketDetailClient({
+  marketId,
+  initialMarket,
+  initialBets,
+  initialOddsHistory,
+}: MarketDetailClientProps): JSX.Element {
+  const { market } = useMarket(marketId);
+  const [bets, setBets] = useState<Bet[]>(initialBets);
+  const [showDispute, setShowDispute] = useState(false);
+
+  // Use live polled data once available, fall back to SSR initial data
+  const m = market ?? initialMarket;
+  const oddsHistory = initialOddsHistory;
+
+  const poolA = BigInt(m.poolA);
+  const poolB = BigInt(m.poolB);
+  const total = poolA + poolB;
+  const oddsA = total === BigInt(0) ? 50 : Number((poolA * BigInt(100)) / total);
+  const oddsB = 100 - oddsA;
+
+  return (
+    <div className="space-y-5">
+      {/* Header */}
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="text-xl font-bold text-white">
+          {m.fighterA.name} vs {m.fighterB.name}
+        </h1>
+        <MarketStatusBadge status={m.status} />
+      </div>
+
+      <CountdownTimer
+        targetTimestamp={Math.floor(new Date(m.bettingEndsAt).getTime() / 1000)}
+        label="Betting closes in"
+      />
+
+      {/* Fighter cards */}
+      <div className="flex flex-col md:flex-row gap-4">
+        <FighterCard fighter={m.fighterA} side="A" poolAmount={poolA} impliedOdds={oddsA} />
+        <FighterCard fighter={m.fighterB} side="B" poolAmount={poolB} impliedOdds={oddsB} />
+      </div>
+
+      <MarketOddsBar
+        poolA={poolA}
+        poolB={poolB}
+        fighterAName={m.fighterA.name}
+        fighterBName={m.fighterB.name}
+      />
+
+      <MarketOddsChart marketId={marketId} historicalOdds={oddsHistory} />
+
+      <BettingInterface
+        market={m}
+        onBetPlaced={(bet) => setBets((prev) => [bet, ...prev])}
+      />
+
+      {/* Bet history */}
+      {bets.length > 0 && (
+        <div className="bg-gray-800 rounded-xl p-4">
+          <h2 className="text-sm font-semibold text-gray-300 mb-3">Public Bet History</h2>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="text-xs text-gray-500 border-b border-gray-700">
+                  <th className="pb-2 text-left pr-4">Address</th>
+                  <th className="pb-2 text-left pr-4">Side</th>
+                  <th className="pb-2 text-left pr-4">Amount</th>
+                  <th className="pb-2 text-left">Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {bets.map((bet) => <BetHistoryRow key={bet.id} bet={bet} />)}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Dispute section */}
+      {isInDisputeWindow(m) && !showDispute && (
+        <button
+          onClick={() => setShowDispute(true)}
+          className="w-full rounded-xl border border-amber-500 bg-amber-500/10 px-4 py-3 text-sm font-medium text-amber-400 hover:bg-amber-500/20 transition-colors"
+        >
+          Dispute Result
+        </button>
+      )}
+
+      {showDispute && (
+        <DisputeModal market={m} onDisputed={() => setShowDispute(false)} />
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -75,7 +75,38 @@ export interface MarketQueryParams extends MarketFilters {
   limit?: number;
 }
 
-export type MarketFilters = MarketQueryParams;
+// ─── ERROR ────────────────────────────────────────────────────────────────────
+
+export class ApiError extends Error {
+  constructor(public status: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+// ─── HELPERS ─────────────────────────────────────────────────────────────────
+
+const BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+async function apiFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new ApiError(res.status, text);
+  }
+  return res.json() as Promise<T>;
+}
+
+function toQueryString(params: Record<string, string | number | undefined>): string {
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined) qs.set(k, String(v));
+  }
+  const s = qs.toString();
+  return s ? `?${s}` : "";
+}
 
 // ─── API FUNCTIONS ────────────────────────────────────────────────────────────
 
@@ -84,7 +115,8 @@ export type MarketFilters = MarketQueryParams;
  * Fetches the market list with optional filters and pagination.
  */
 export async function fetchMarkets(params?: MarketQueryParams): Promise<Market[]> {
-  throw new Error("Not implemented");
+  const qs = toQueryString(params as Record<string, string | number | undefined> ?? {});
+  return apiFetch<Market[]>(`/api/markets${qs}`);
 }
 
 /**
@@ -92,7 +124,7 @@ export async function fetchMarkets(params?: MarketQueryParams): Promise<Market[]
  * Fetches a single market by ID. Throws if not found.
  */
 export async function fetchMarketById(market_id: string): Promise<Market> {
-  throw new Error("Not implemented");
+  return apiFetch<Market>(`/api/markets/${market_id}`);
 }
 
 /**
@@ -100,7 +132,7 @@ export async function fetchMarketById(market_id: string): Promise<Market> {
  * Fetches aggregated stats for a market.
  */
 export async function fetchMarketStats(market_id: string): Promise<MarketStats> {
-  throw new Error("Not implemented");
+  return apiFetch<MarketStats>(`/api/markets/${market_id}/stats`);
 }
 
 /**
@@ -108,7 +140,7 @@ export async function fetchMarketStats(market_id: string): Promise<MarketStats> 
  * Fetches all bets for a market.
  */
 export async function fetchMarketBets(market_id: string): Promise<Bet[]> {
-  throw new Error("Not implemented");
+  return apiFetch<Bet[]>(`/api/markets/${market_id}/bets`);
 }
 
 /**
@@ -116,7 +148,7 @@ export async function fetchMarketBets(market_id: string): Promise<Bet[]> {
  * Fetches a user's full bet history.
  */
 export async function fetchBetsByAddress(address: string): Promise<Bet[]> {
-  throw new Error("Not implemented");
+  return apiFetch<Bet[]>(`/api/bets/${address}`);
 }
 
 /**
@@ -124,19 +156,22 @@ export async function fetchBetsByAddress(address: string): Promise<Bet[]> {
  * Fetches portfolio summary stats for a wallet address.
  */
 export async function fetchPortfolioSummary(address: string): Promise<PortfolioSummary> {
-  throw new Error("Not implemented");
+  return apiFetch<PortfolioSummary>(`/api/bets/${address}/portfolio`);
 }
 
 /**
  * GET /api/bets/payout-estimate?market_id=&side=&amount=
  * Returns estimated payout for a hypothetical bet without placing it.
+ * Amount and return value are in stroops (BigInt).
  */
 export async function fetchPayoutEstimate(
   market_id: string,
   side: BetSide,
   amount: bigint
 ): Promise<bigint> {
-  throw new Error("Not implemented");
+  const qs = toQueryString({ market_id, side, amount: amount.toString() });
+  const data = await apiFetch<{ estimate: string }>(`/api/bets/payout-estimate${qs}`);
+  return BigInt(data.estimate);
 }
 
 /**
@@ -144,5 +179,5 @@ export async function fetchPayoutEstimate(
  * Fetches historical odds snapshots for the market odds chart.
  */
 export async function fetchOddsHistory(market_id: string): Promise<OddsSnapshot[]> {
-  throw new Error("Not implemented");
+  return apiFetch<OddsSnapshot[]>(`/api/markets/${market_id}/odds-history`);
 }


### PR DESCRIPTION
## Summary

Implements three frontend issues in a single PR.

### #949 — API client (lib/api.ts)
- All 8 functions implemented with `NEXT_PUBLIC_API_URL` as base
- `ApiError` class with `status` and `message` for non-2xx responses
- `fetchPayoutEstimate` parses `estimate` string to `BigInt`
- Query params serialized via `URLSearchParams`

### #945 — Home page (app/page.tsx)
- Server-side initial data load with ISR (30s revalidate) — no loading flash
- Hero section with headline and description
- `HomePageContent` client component with **Active / Upcoming / Resolved** tabs
  - Active = Open + Locked markets
  - Upcoming = Open only
  - Resolved = Resolved only

### #946 — Market detail page (app/markets/[id]/page.tsx)
- SSR fetch of market, bets, and odds history; `notFound()` if market missing
- `MarketDetailClient` client component:
  - `useMarket` polls every 10s for live odds
  - FighterCards, MarketOddsBar, MarketOddsChart, BettingInterface
  - Public bet history table
  - Dispute Result button + DisputeModal visible only within 24h dispute window
  - BettingInterface disabled when market is not Open

## Tests
- 14 unit tests in `__tests__/api.test.ts` covering all 8 functions, ApiError, BigInt handling, and query param construction (all passing)

## Tested
- TypeScript: no errors in new files
- Jest: 14/14 tests pass
closes #949 
closes #945 
closes #946 