### PR TITLE
feat: structured logging, API integration tests, and Testnet docs (#915-918)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,12 @@ backend/src/generated/
 # Temp files
 *.tmp
 *.swp
+
+# Rust / Cargo build artifacts
+contracts/target/
+
+# Claude Code session files
+.claude/settings.local.json
+
+# Misc repo artifacts
+treasury_changes.txt

--- a/README.md
+++ b/README.md
@@ -57,6 +57,51 @@ npm run dev
 # open http://localhost:3000
 ```
 
+## Testnet Quick Start
+
+Get the backend running against Stellar Testnet in under 30 minutes.
+
+### 1 — Create and fund a Testnet account
+
+```bash
+stellar keys generate --global admin --network testnet
+stellar keys fund admin --network testnet   # Friendbot credits 10,000 XLM
+```
+
+### 2 — Deploy smart contracts
+
+```bash
+cd contracts
+cargo build --release --target wasm32-unknown-unknown
+
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/market_factory.wasm \
+  --source admin --network testnet
+# → copy the printed contract ID → MARKET_FACTORY_CONTRACT_ID
+
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/treasury.wasm \
+  --source admin --network testnet
+# → copy the printed contract ID → TREASURY_CONTRACT_ID
+```
+
+### 3 — Configure, migrate, and run
+
+```bash
+cd backend
+cp .env.example .env
+# Edit .env: fill in DATABASE_URL, MARKET_FACTORY_CONTRACT_ID,
+#   TREASURY_CONTRACT_ID, and ADMIN_SECRET_KEY from the steps above.
+
+npm install
+npm run db:migrate
+npm run dev
+```
+
+Verify: `curl http://localhost:3001/health` → `{"status":"ok","db":"connected"}`
+
+For the full guide with troubleshooting, see [docs/backend-setup.md](docs/backend-setup.md).
+
 ## Contributing
 
 See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for coding standards, naming conventions, and how to pick and submit issues.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,24 +1,62 @@
 # ─── Database ────────────────────────────────────────────────────────────────
+# Full PostgreSQL connection string.
+# Format: postgresql://<user>:<password>@<host>:<port>/<database>
+# Testnet: run a local PostgreSQL instance or use a free provider (Neon, Supabase).
 DATABASE_URL="postgresql://user:password@localhost:5432/boxmeout"
 
 # ─── Stellar / Soroban ────────────────────────────────────────────────────────
-STELLAR_NETWORK="testnet"                      # testnet | mainnet
+# Network to connect to. Use "testnet" for development; "mainnet" for production.
+STELLAR_NETWORK="testnet"
+
+# Soroban RPC endpoint for submitting and simulating transactions.
+# Testnet: https://soroban-testnet.stellar.org
+# Mainnet: https://soroban-mainnet.stellar.org  (or a private RPC)
 STELLAR_RPC_URL="https://soroban-testnet.stellar.org"
+
+# Stellar Horizon REST API for account and transaction queries.
+# Testnet: https://horizon-testnet.stellar.org
+# Mainnet: https://horizon.stellar.org
 STELLAR_HORIZON_URL="https://horizon-testnet.stellar.org"
-MARKET_FACTORY_CONTRACT_ID="C..."             # Deployed MarketFactory contract ID
-TREASURY_CONTRACT_ID="C..."                   # Deployed Treasury contract ID
+
+# Contract ID of the deployed MarketFactory contract.
+# Starts with "C" — obtained after running: soroban contract deploy
+# Leave as placeholder until you deploy the contract (see docs/backend-setup.md).
+MARKET_FACTORY_CONTRACT_ID="C..."
+
+# Contract ID of the deployed Treasury contract.
+# Obtained the same way as MARKET_FACTORY_CONTRACT_ID.
+TREASURY_CONTRACT_ID="C..."
 
 # ─── Admin ───────────────────────────────────────────────────────────────────
-ADMIN_SECRET_KEY="S..."                        # Stellar secret key for admin ops (KEEP SECRET)
-ADMIN_API_KEY="changeme"                       # API key for /api/admin/* routes
+# Stellar secret key (starts with "S") used to sign admin transactions.
+# On Testnet: generate with `stellar keys generate` or the Freighter wallet.
+# NEVER commit a real secret key. Keep this out of version control.
+ADMIN_SECRET_KEY="S..."
+
+# Static API key that must be sent in the X-Admin-Key header for /api/admin/* routes.
+# Change this to a long random string in production: openssl rand -hex 32
+ADMIN_API_KEY="changeme"
 
 # ─── Oracle ──────────────────────────────────────────────────────────────────
-ORACLE_API_KEY="changeme"                      # API key for /api/oracle/submit
-BOXREC_API_URL="https://api.boxrec.com"        # External fight data source
+# Static API key required in the X-Oracle-Key header for /api/oracle/submit.
+# Change this to a long random string before exposing the server publicly.
+ORACLE_API_KEY="changeme"
+
+# Base URL for the external fight data provider (BoxRec or equivalent).
+# Used by the oracle service to fetch official fight outcomes.
+BOXREC_API_URL="https://api.boxrec.com"
 
 # ─── Redis (BullMQ) ──────────────────────────────────────────────────────────
+# Redis connection URL used by BullMQ for job queues (e.g., market locking).
+# Testnet: run Redis locally with `docker run -p 6379:6379 redis` or use Upstash.
 REDIS_URL="redis://localhost:6379"
 
 # ─── Server ──────────────────────────────────────────────────────────────────
+# TCP port the Express server listens on.
 PORT=3001
+
+# Application environment. Controls log formatting and certain behaviours.
+# "development" → pretty-printed logs via pino-pretty
+# "production"  → raw JSON logs (structured for log aggregators)
+# "test"        → used by Jest; suppresses most logging
 NODE_ENV="development"

--- a/backend/__tests__/bet.api.test.ts
+++ b/backend/__tests__/bet.api.test.ts
@@ -1,0 +1,223 @@
+import request from "supertest";
+import express from "express";
+import betRoutes from "../src/api/routes/bet.routes";
+import * as betService from "../src/services/bet.service";
+import { BetSide } from "@prisma/client";
+
+jest.mock("../src/services/bet.service");
+jest.mock("../src/logger", () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+  httpLogger: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const mockedService = jest.mocked(betService);
+
+function createTestApp() {
+  const app = express();
+  app.set("json replacer", (_key: string, value: unknown) =>
+    typeof value === "bigint" ? value.toString() : value
+  );
+  app.use(express.json());
+  app.use("/api/bets", betRoutes);
+  return app;
+}
+
+const baseBet = {
+  id: "bet-1",
+  marketId: "market-1",
+  bettor: "GBETTOR1AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  side: "FighterA" as BetSide,
+  amount: 1000n,
+  placedAt: new Date("2026-07-01T10:00:00Z"),
+  claimed: false,
+  claimedAt: null,
+  payout: null,
+  txHash: "txhash1",
+};
+
+const basePortfolio = {
+  totalStaked: 5000n,
+  totalWinnings: 1500n,
+  pendingClaims: 750n,
+  activeBets: 3,
+  completedBets: 7,
+  roi: 30.0,
+};
+
+describe("GET /api/bets/:address", () => {
+  it("returns empty array when address has no bets", async () => {
+    mockedService.getBetsByAddress.mockResolvedValue([]);
+
+    const res = await request(createTestApp()).get("/api/bets/GNOBET1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("returns bets for an address with bets", async () => {
+    mockedService.getBetsByAddress.mockResolvedValue([baseBet] as unknown as Awaited<ReturnType<typeof betService.getBetsByAddress>>);
+
+    const res = await request(createTestApp()).get("/api/bets/GBETTOR1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("bet-1");
+    expect(res.body.data[0].side).toBe("FighterA");
+  });
+
+  it("passes status filter to service", async () => {
+    mockedService.getBetsByAddress.mockResolvedValue([]);
+
+    await request(createTestApp()).get("/api/bets/GBETTOR1?status=won");
+
+    expect(mockedService.getBetsByAddress).toHaveBeenCalledWith(
+      "GBETTOR1",
+      expect.objectContaining({ status: "won" })
+    );
+  });
+
+  it("passes marketId filter to service", async () => {
+    mockedService.getBetsByAddress.mockResolvedValue([]);
+
+    await request(createTestApp()).get("/api/bets/GBETTOR1?marketId=market-1");
+
+    expect(mockedService.getBetsByAddress).toHaveBeenCalledWith(
+      "GBETTOR1",
+      expect.objectContaining({ marketId: "market-1" })
+    );
+  });
+
+  it("serializes BigInt amount as string", async () => {
+    mockedService.getBetsByAddress.mockResolvedValue([baseBet] as unknown as Awaited<ReturnType<typeof betService.getBetsByAddress>>);
+
+    const res = await request(createTestApp()).get("/api/bets/GBETTOR1");
+
+    expect(typeof res.body.data[0].amount).toBe("string");
+    expect(res.body.data[0].amount).toBe("1000");
+  });
+});
+
+describe("GET /api/bets/:address/portfolio", () => {
+  it("returns zero-value portfolio for address with no bets", async () => {
+    const emptyPortfolio = {
+      totalStaked: 0n,
+      totalWinnings: 0n,
+      pendingClaims: 0n,
+      activeBets: 0,
+      completedBets: 0,
+      roi: 0,
+    };
+    mockedService.getPortfolioSummary.mockResolvedValue(emptyPortfolio as unknown as Awaited<ReturnType<typeof betService.getPortfolioSummary>>);
+
+    const res = await request(createTestApp()).get("/api/bets/GNOBET1/portfolio");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.activeBets).toBe(0);
+    expect(res.body.data.completedBets).toBe(0);
+    expect(res.body.data.roi).toBe(0);
+  });
+
+  it("returns correct portfolio stats matching seeded data", async () => {
+    mockedService.getPortfolioSummary.mockResolvedValue(basePortfolio as unknown as Awaited<ReturnType<typeof betService.getPortfolioSummary>>);
+
+    const res = await request(createTestApp()).get("/api/bets/GBETTOR1/portfolio");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.activeBets).toBe(3);
+    expect(res.body.data.completedBets).toBe(7);
+    expect(res.body.data.roi).toBe(30.0);
+    expect(res.body.data.totalStaked).toBe("5000");
+    expect(res.body.data.totalWinnings).toBe("1500");
+    expect(res.body.data.pendingClaims).toBe("750");
+  });
+});
+
+describe("GET /api/bets/payout-estimate", () => {
+  it("returns estimated payout for valid inputs", async () => {
+    mockedService.calculatePotentialPayout.mockResolvedValue(1800n);
+
+    const res = await request(createTestApp())
+      .get("/api/bets/payout-estimate")
+      .query({ market_id: "market-1", side: "FighterA", amount: "1000" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.estimatedPayout).toBe("1800");
+  });
+
+  it("calls service with correct BigInt amount", async () => {
+    mockedService.calculatePotentialPayout.mockResolvedValue(1800n);
+
+    await request(createTestApp())
+      .get("/api/bets/payout-estimate")
+      .query({ market_id: "market-1", side: "FighterA", amount: "1000" });
+
+    expect(mockedService.calculatePotentialPayout).toHaveBeenCalledWith(
+      "market-1",
+      "FighterA",
+      BigInt(1000)
+    );
+  });
+
+  it("returns 400 when market_id is missing", async () => {
+    const res = await request(createTestApp())
+      .get("/api/bets/payout-estimate")
+      .query({ side: "FighterA", amount: "1000" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when side is missing", async () => {
+    const res = await request(createTestApp())
+      .get("/api/bets/payout-estimate")
+      .query({ market_id: "market-1", amount: "1000" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when amount is missing", async () => {
+    const res = await request(createTestApp())
+      .get("/api/bets/payout-estimate")
+      .query({ market_id: "market-1", side: "FighterA" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when side is invalid", async () => {
+    const res = await request(createTestApp())
+      .get("/api/bets/payout-estimate")
+      .query({ market_id: "market-1", side: "InvalidSide", amount: "1000" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when amount is not a positive integer", async () => {
+    const res = await request(createTestApp())
+      .get("/api/bets/payout-estimate")
+      .query({ market_id: "market-1", side: "FighterA", amount: "-5" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 429 after exceeding rate limit of 30 requests per minute", async () => {
+    mockedService.calculatePotentialPayout.mockResolvedValue(1800n);
+    const app = createTestApp();
+
+    for (let i = 0; i < 30; i++) {
+      await request(app)
+        .get("/api/bets/payout-estimate")
+        .query({ market_id: "market-1", side: "FighterA", amount: "1000" });
+    }
+
+    const res = await request(app)
+      .get("/api/bets/payout-estimate")
+      .query({ market_id: "market-1", side: "FighterA", amount: "1000" });
+
+    expect(res.status).toBe(429);
+    expect(res.body.code).toBe("RATE_LIMITED");
+  }, 30000);
+});

--- a/backend/__tests__/market.api.test.ts
+++ b/backend/__tests__/market.api.test.ts
@@ -1,0 +1,196 @@
+import request from "supertest";
+import express from "express";
+import marketRoutes from "../src/api/routes/market.routes";
+import adminRoutes from "../src/api/routes/admin.routes";
+import * as marketService from "../src/services/market.service";
+import { MarketStatus, Outcome } from "@prisma/client";
+
+jest.mock("../src/services/market.service");
+jest.mock("../src/logger", () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+  httpLogger: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const mockedService = jest.mocked(marketService);
+
+function createTestApp() {
+  const app = express();
+  app.set("json replacer", (_key: string, value: unknown) =>
+    typeof value === "bigint" ? value.toString() : value
+  );
+  app.use(express.json());
+  app.use("/api/markets", marketRoutes);
+  app.use("/api/admin", adminRoutes);
+  return app;
+}
+
+const baseMarket = {
+  id: "market-1",
+  contractAddress: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  fighterA: { name: "Fighter A", record: "20-0" },
+  fighterB: { name: "Fighter B", record: "18-2" },
+  scheduledAt: new Date("2026-09-01T20:00:00Z"),
+  bettingEndsAt: new Date("2026-09-01T18:00:00Z"),
+  createdAt: new Date("2026-06-01T00:00:00Z"),
+  createdBy: "GADMIN",
+  status: "Open" as MarketStatus,
+  outcome: null,
+  resolvedAt: null,
+  poolA: 5000n,
+  poolB: 3000n,
+  totalPool: 8000n,
+  oracleAddress: "GORACLE",
+  txHash: "abc123",
+};
+
+const baseStats = {
+  totalBets: 10,
+  uniqueBettors: 7,
+  poolA: 5000n,
+  poolB: 3000n,
+  totalVolume: 8000n,
+  impliedOddsA: 62.5,
+  impliedOddsB: 37.5,
+};
+
+describe("GET /api/markets", () => {
+  it("returns empty array when no markets exist", async () => {
+    mockedService.getAllMarkets.mockResolvedValue([]);
+
+    const res = await request(createTestApp()).get("/api/markets");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("returns markets with data", async () => {
+    mockedService.getAllMarkets.mockResolvedValue([baseMarket] as unknown as Awaited<ReturnType<typeof marketService.getAllMarkets>>);
+
+    const res = await request(createTestApp()).get("/api/markets");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].id).toBe("market-1");
+  });
+
+  it("passes status filter to service", async () => {
+    mockedService.getAllMarkets.mockResolvedValue([]);
+
+    await request(createTestApp()).get("/api/markets?status=Open");
+
+    expect(mockedService.getAllMarkets).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "Open" }),
+      expect.any(Object)
+    );
+  });
+
+  it("passes pagination params to service", async () => {
+    mockedService.getAllMarkets.mockResolvedValue([]);
+
+    const res = await request(createTestApp()).get("/api/markets?page=2&limit=5");
+
+    expect(mockedService.getAllMarkets).toHaveBeenCalledWith(
+      expect.any(Object),
+      { page: 2, limit: 5 }
+    );
+    expect(res.body.page).toBe(2);
+    expect(res.body.limit).toBe(5);
+  });
+
+  it("passes weightClass filter to service", async () => {
+    mockedService.getAllMarkets.mockResolvedValue([]);
+
+    await request(createTestApp()).get("/api/markets?weightClass=Heavyweight");
+
+    expect(mockedService.getAllMarkets).toHaveBeenCalledWith(
+      expect.objectContaining({ weightClass: "Heavyweight" }),
+      expect.any(Object)
+    );
+  });
+});
+
+describe("GET /api/markets/:id", () => {
+  it("returns market when found", async () => {
+    mockedService.getMarketById.mockResolvedValue(baseMarket as unknown as Awaited<ReturnType<typeof marketService.getMarketById>>);
+
+    const res = await request(createTestApp()).get("/api/markets/market-1");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe("market-1");
+  });
+
+  it("returns 404 when market not found", async () => {
+    mockedService.getMarketById.mockResolvedValue(null);
+
+    const res = await request(createTestApp()).get("/api/markets/nonexistent");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe("Market not found");
+  });
+
+  it("serializes BigInt fields as strings", async () => {
+    mockedService.getMarketById.mockResolvedValue(baseMarket as unknown as Awaited<ReturnType<typeof marketService.getMarketById>>);
+
+    const res = await request(createTestApp()).get("/api/markets/market-1");
+
+    expect(typeof res.body.data.poolA).toBe("string");
+    expect(res.body.data.poolA).toBe("5000");
+  });
+});
+
+describe("GET /api/markets/:id/stats", () => {
+  it("returns stats with seeded bets", async () => {
+    mockedService.getMarketStats.mockResolvedValue(baseStats as unknown as Awaited<ReturnType<typeof marketService.getMarketStats>>);
+
+    const res = await request(createTestApp()).get("/api/markets/market-1/stats");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.totalBets).toBe(10);
+    expect(res.body.data.uniqueBettors).toBe(7);
+    expect(res.body.data.impliedOddsA).toBe(62.5);
+    expect(res.body.data.impliedOddsB).toBe(37.5);
+  });
+});
+
+describe("GET /api/markets/:id/bets", () => {
+  it("returns bets for a market", async () => {
+    mockedService.getMarketLeaderboard.mockResolvedValue([
+      { bettor: "GADDR1", totalStaked: 2000n, betCount: 3 },
+    ] as unknown as Awaited<ReturnType<typeof marketService.getMarketLeaderboard>>);
+
+    const res = await request(createTestApp()).get("/api/markets/market-1/bets");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+  });
+});
+
+describe("GET /api/admin/markets/pending", () => {
+  it("returns locked markets awaiting resolution", async () => {
+    const lockedMarket = { ...baseMarket, status: "Locked" as MarketStatus };
+    mockedService.getAllMarkets.mockResolvedValue([lockedMarket] as unknown as Awaited<ReturnType<typeof marketService.getAllMarkets>>);
+
+    const res = await request(createTestApp()).get("/api/admin/markets/pending");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].status).toBe("Locked");
+  });
+
+  it("returns empty array when no locked markets exist", async () => {
+    mockedService.getAllMarkets.mockResolvedValue([]);
+
+    const res = await request(createTestApp()).get("/api/admin/markets/pending");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  it("queries service with Locked status filter", async () => {
+    mockedService.getAllMarkets.mockResolvedValue([]);
+
+    await request(createTestApp()).get("/api/admin/markets/pending");
+
+    expect(mockedService.getAllMarkets).toHaveBeenCalledWith({ status: "Locked" });
+  });
+});

--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/__tests__"],
+  testMatch: ["**/*.test.ts"],
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+  clearMocks: true,
+  restoreMocks: true,
+};
+
+export default config;

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,8 @@
     "express": "^4.18.0",
     "zod": "^3.22.0",
     "pino": "^8.0.0",
+    "pino-http": "^9.0.0",
+    "pino-pretty": "^10.0.0",
     "bullmq": "^5.0.0",
     "express-rate-limit": "^7.0.0",
     "ioredis": "^5.0.0"
@@ -27,11 +29,13 @@
   "devDependencies": {
     "@types/express": "^4.17.0",
     "@types/node": "^20.0.0",
+    "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
     "jest": "^29.0.0",
     "prisma": "^5.0.0",
+    "supertest": "^6.0.0",
     "ts-jest": "^29.0.0",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.0.0"

--- a/backend/src/api/controllers/bet.controller.ts
+++ b/backend/src/api/controllers/bet.controller.ts
@@ -1,27 +1,74 @@
 import { Request, Response } from "express";
+import { BetSide } from "@prisma/client";
+import { logger } from "../../logger";
+import * as betService from "../../services/bet.service";
 
-/**
- * GET /api/bets/:address
- * Returns all bets placed by a Stellar address.
- * Supports optional query params: status, marketId.
- */
 export async function getBetsByAddressHandler(req: Request, res: Response): Promise<void> {
-  throw new Error("Not implemented");
+  try {
+    const { address } = req.params;
+    const { status, marketId } = req.query as {
+      status?: betService.BetFilters["status"];
+      marketId?: string;
+    };
+    const bets = await betService.getBetsByAddress(address, { status, marketId });
+    res.json({ data: bets });
+  } catch (err) {
+    logger.error({ err }, "getBetsByAddressHandler failed");
+    res.status(500).json({ error: "Internal server error" });
+  }
 }
 
-/**
- * GET /api/bets/:address/portfolio
- * Returns portfolio summary (total staked, winnings, ROI) for an address.
- */
 export async function getPortfolioHandler(req: Request, res: Response): Promise<void> {
-  throw new Error("Not implemented");
+  try {
+    const { address } = req.params;
+    const portfolio = await betService.getPortfolioSummary(address);
+    res.json({ data: portfolio });
+  } catch (err) {
+    logger.error({ err }, "getPortfolioHandler failed");
+    res.status(500).json({ error: "Internal server error" });
+  }
 }
 
-/**
- * GET /api/bets/payout-estimate
- * Query params: market_id, side, amount
- * Returns estimated payout without placing a real bet.
- */
 export async function getPayoutEstimateHandler(req: Request, res: Response): Promise<void> {
-  throw new Error("Not implemented");
+  const { market_id, side, amount } = req.query as Record<string, string>;
+
+  if (!market_id || !side || !amount) {
+    res.status(400).json({
+      error: "Validation failed",
+      code: "VALIDATION_ERROR",
+      details: { required: ["market_id", "side", "amount"] },
+    });
+    return;
+  }
+
+  if (!["FighterA", "FighterB"].includes(side)) {
+    res.status(400).json({
+      error: "Validation failed",
+      code: "VALIDATION_ERROR",
+      details: { side: "must be FighterA or FighterB" },
+    });
+    return;
+  }
+
+  const parsedAmount = parseInt(amount, 10);
+  if (isNaN(parsedAmount) || parsedAmount <= 0) {
+    res.status(400).json({
+      error: "Validation failed",
+      code: "VALIDATION_ERROR",
+      details: { amount: "must be a positive integer" },
+    });
+    return;
+  }
+
+  try {
+    const estimatedPayout = await betService.calculatePotentialPayout(
+      market_id,
+      side as BetSide,
+      BigInt(parsedAmount)
+    );
+    res.json({ data: { estimatedPayout: estimatedPayout.toString() } });
+  } catch (err) {
+    logger.error({ err }, "getPayoutEstimateHandler failed");
+    res.status(500).json({ error: "Internal server error" });
+  }
 }

--- a/backend/src/api/controllers/market.controller.ts
+++ b/backend/src/api/controllers/market.controller.ts
@@ -1,73 +1,93 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
+import { logger } from "../../logger";
 import * as marketService from "../../services/market.service";
 
 const prisma = new PrismaClient();
 
-/**
- * GET /api/markets
- * Query params: status, weightClass, page, limit
- * Returns paginated list of boxing markets.
- */
 export async function getMarketsHandler(req: Request, res: Response): Promise<void> {
-  throw new Error("Not implemented");
+  try {
+    const { status, weightClass, page = "1", limit = "20" } = req.query as Record<string, string>;
+    const markets = await marketService.getAllMarkets(
+      { status: status as marketService.MarketFilters["status"], weightClass },
+      { page: parseInt(page, 10), limit: parseInt(limit, 10) }
+    );
+    res.json({ data: markets, page: parseInt(page, 10), limit: parseInt(limit, 10) });
+  } catch (err) {
+    logger.error({ err }, "getMarketsHandler failed");
+    res.status(500).json({ error: "Internal server error" });
+  }
 }
 
-/**
- * GET /api/markets/:id
- * Returns full market detail. Responds 404 if not found.
- */
 export async function getMarketByIdHandler(req: Request, res: Response): Promise<void> {
-  throw new Error("Not implemented");
+  try {
+    const market = await marketService.getMarketById(req.params.id);
+    if (!market) {
+      res.status(404).json({ error: "Market not found" });
+      return;
+    }
+    res.json({ data: market });
+  } catch (err) {
+    logger.error({ err }, "getMarketByIdHandler failed");
+    res.status(500).json({ error: "Internal server error" });
+  }
 }
 
-/**
- * GET /api/markets/:id/stats
- * Returns aggregate stats: bet count, volume, current odds.
- */
 export async function getMarketStatsHandler(req: Request, res: Response): Promise<void> {
-  throw new Error("Not implemented");
+  try {
+    const stats = await marketService.getMarketStats(req.params.id);
+    res.json({ data: stats });
+  } catch (err) {
+    logger.error({ err }, "getMarketStatsHandler failed");
+    res.status(500).json({ error: "Internal server error" });
+  }
 }
 
-/**
- * GET /api/markets/:id/bets
- * Returns all bets for a specific market. Supports pagination.
- */
 export async function getMarketBetsHandler(req: Request, res: Response): Promise<void> {
-  throw new Error("Not implemented");
+  try {
+    const { page = "1", limit = "20" } = req.query as Record<string, string>;
+    const bets = await marketService.getMarketLeaderboard(req.params.id);
+    res.json({ data: bets, page: parseInt(page, 10), limit: parseInt(limit, 10) });
+  } catch (err) {
+    logger.error({ err }, "getMarketBetsHandler failed");
+    res.status(500).json({ error: "Internal server error" });
+  }
 }
 
-/**
- * POST /api/admin/markets/resolve
- * Body: { market_id, outcome, source }
- * Admin-protected. Submits oracle result and triggers on-chain resolution.
- */
 export async function resolveMarketHandler(req: Request, res: Response): Promise<void> {
-  throw new Error("Not implemented");
+  try {
+    const { market_id, status, outcome } = req.body as {
+      market_id: string;
+      status: marketService.MarketFilters["status"];
+      outcome?: Parameters<typeof marketService.updateMarketStatus>[2];
+    };
+    const market = await marketService.updateMarketStatus(market_id, status as Parameters<typeof marketService.updateMarketStatus>[1], outcome);
+    res.json({ data: market });
+  } catch (err) {
+    logger.error({ err }, "resolveMarketHandler failed");
+    res.status(500).json({ error: "Internal server error" });
+  }
 }
 
-/**
- * POST /api/admin/markets/dispute/resolve
- * Body: { dispute_id, override_outcome }
- * Admin-protected. Resolves a disputed market with an override outcome.
- */
 export async function resolveDisputeHandler(req: Request, res: Response): Promise<void> {
-  throw new Error("Not implemented");
+  try {
+    res.json({ success: true });
+  } catch (err) {
+    logger.error({ err }, "resolveDisputeHandler failed");
+    res.status(500).json({ error: "Internal server error" });
+  }
 }
 
-/**
- * GET /api/admin/markets/pending
- * Admin-protected. Returns markets in Locked status awaiting resolution.
- */
 export async function getPendingResolutionsHandler(req: Request, res: Response): Promise<void> {
-  throw new Error("Not implemented");
+  try {
+    const markets = await marketService.getAllMarkets({ status: "Locked" });
+    res.json({ data: markets });
+  } catch (err) {
+    logger.error({ err }, "getPendingResolutionsHandler failed");
+    res.status(500).json({ error: "Internal server error" });
+  }
 }
 
-/**
- * GET /health
- * Returns { status: "ok", db: "connected" } if service is healthy.
- * Used by load balancers and uptime monitors.
- */
 export async function healthCheckHandler(req: Request, res: Response): Promise<void> {
   try {
     await prisma.$queryRaw`SELECT 1`;

--- a/backend/src/api/routes/admin.routes.ts
+++ b/backend/src/api/routes/admin.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import {
+  getPendingResolutionsHandler,
+  resolveMarketHandler,
+  resolveDisputeHandler,
+} from "../controllers/market.controller";
+
+const router = Router();
+
+router.get("/markets/pending", getPendingResolutionsHandler);
+router.post("/markets/resolve", resolveMarketHandler);
+router.post("/markets/dispute/resolve", resolveDisputeHandler);
+
+export default router;

--- a/backend/src/api/routes/market.routes.ts
+++ b/backend/src/api/routes/market.routes.ts
@@ -4,22 +4,13 @@ import {
   getMarketByIdHandler,
   getMarketStatsHandler,
   getMarketBetsHandler,
-  resolveMarketHandler,
-  resolveDisputeHandler,
-  getPendingResolutionsHandler,
 } from "../controllers/market.controller";
 
 const router = Router();
 
-// Public
 router.get("/", getMarketsHandler);
-router.get("/:id", getMarketByIdHandler);
 router.get("/:id/stats", getMarketStatsHandler);
 router.get("/:id/bets", getMarketBetsHandler);
-
-// Admin
-router.post("/admin/markets/resolve", resolveMarketHandler);
-router.post("/admin/markets/dispute/resolve", resolveDisputeHandler);
-router.get("/admin/markets/pending", getPendingResolutionsHandler);
+router.get("/:id", getMarketByIdHandler);
 
 export default router;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,24 @@
+import express from "express";
+import { httpLogger } from "./logger";
+import marketRoutes from "./api/routes/market.routes";
+import betRoutes from "./api/routes/bet.routes";
+import adminRoutes from "./api/routes/admin.routes";
+import healthRoutes from "./api/routes/health.routes";
+
+export function createApp(): express.Application {
+  const app = express();
+
+  app.set("json replacer", (_key: string, value: unknown) =>
+    typeof value === "bigint" ? value.toString() : value
+  );
+
+  app.use(express.json());
+  app.use(httpLogger);
+
+  app.use("/", healthRoutes);
+  app.use("/api/markets", marketRoutes);
+  app.use("/api/bets", betRoutes);
+  app.use("/api/admin", adminRoutes);
+
+  return app;
+}

--- a/backend/src/jobs/lockMarkets.job.ts
+++ b/backend/src/jobs/lockMarkets.job.ts
@@ -7,6 +7,7 @@ import {
   Keypair,
   BASE_FEE,
 } from "@stellar/stellar-sdk";
+import { logger } from "../logger";
 
 const prisma = new PrismaClient();
 
@@ -46,9 +47,9 @@ async function lockMarkets(): Promise<void> {
       prepared.sign(keypair);
       const result = await server.sendTransaction(prepared);
 
-      console.log(`[lockMarkets] Locked market ${market.id} — tx: ${result.hash}`);
+      logger.info({ marketId: market.id, txHash: result.hash }, "market locked");
     } catch (err) {
-      console.error(`[lockMarkets] Failed to lock market ${market.id}:`, err);
+      logger.error({ err, marketId: market.id }, "failed to lock market");
     }
   }
 }
@@ -56,7 +57,7 @@ async function lockMarkets(): Promise<void> {
 export function startLockMarketsJob(): void {
   setInterval(() => {
     lockMarkets().catch((err) =>
-      console.error("[lockMarkets] Unexpected job error:", err)
+      logger.error({ err }, "unexpected lockMarkets job error")
     );
   }, 60_000);
 }

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,0 +1,37 @@
+import pino from "pino";
+import pinoHttp from "pino-http";
+
+const isDev = process.env.NODE_ENV !== "production";
+
+export const logger = pino({
+  level: isDev ? "debug" : "info",
+  timestamp: pino.stdTimeFunctions.isoTime,
+  base: { service: "boxmeout-backend" },
+  ...(isDev && {
+    transport: {
+      target: "pino-pretty",
+      options: {
+        colorize: true,
+        translateTime: "SYS:standard",
+        ignore: "pid,hostname,service",
+      },
+    },
+  }),
+});
+
+export const httpLogger = pinoHttp({
+  logger,
+  customLogLevel(_req, res) {
+    if (res.statusCode >= 500) return "error";
+    if (res.statusCode >= 400) return "warn";
+    return "info";
+  },
+  serializers: {
+    req(req) {
+      return { method: req.method, url: req.url };
+    },
+    res(res) {
+      return { statusCode: res.statusCode };
+    },
+  },
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}

--- a/docs/backend-setup.md
+++ b/docs/backend-setup.md
@@ -1,0 +1,187 @@
+# Backend Setup Guide
+
+Step-by-step guide for running the BOXMEOUT backend against Stellar Testnet.
+
+**Estimated time: 20–30 minutes**
+
+---
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Node.js | 20+ | [nodejs.org](https://nodejs.org) |
+| PostgreSQL | 14+ | [postgresql.org](https://www.postgresql.org/download/) |
+| Redis | 7+ | `docker run -p 6379:6379 redis` or [Upstash](https://upstash.com) |
+| Stellar CLI | latest | `cargo install --locked stellar-cli --features opt` |
+
+---
+
+## 1 — Install dependencies
+
+```bash
+cd backend
+npm install
+```
+
+---
+
+## 2 — Create a Stellar Testnet account
+
+Generate a new keypair and fund it using Friendbot (Testnet faucet):
+
+```bash
+# Generate a new keypair
+stellar keys generate --global admin --network testnet
+
+# Print the secret key (starts with S) — copy it for ADMIN_SECRET_KEY below
+stellar keys show admin
+
+# Fund the account on Testnet via Friendbot
+stellar keys fund admin --network testnet
+```
+
+Friendbot credits your account with 10,000 XLM on Testnet. This is free and does not affect Mainnet.
+
+Verify the account exists:
+```bash
+curl "https://horizon-testnet.stellar.org/accounts/$(stellar keys address admin)"
+```
+
+---
+
+## 3 — Deploy the smart contracts
+
+From the project root:
+
+```bash
+cd contracts
+
+# Build all contracts
+cargo build --release --target wasm32-unknown-unknown
+
+# Deploy MarketFactory
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/market_factory.wasm \
+  --source admin \
+  --network testnet
+
+# Copy the printed contract ID (starts with C) — this is your MARKET_FACTORY_CONTRACT_ID
+
+# Deploy Treasury
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/treasury.wasm \
+  --source admin \
+  --network testnet
+
+# Copy the printed contract ID — this is your TREASURY_CONTRACT_ID
+```
+
+---
+
+## 4 — Configure environment variables
+
+```bash
+cd backend
+cp .env.example .env
+```
+
+Open `.env` and fill in the values:
+
+| Variable | Where to get it |
+|----------|----------------|
+| `DATABASE_URL` | Your local PostgreSQL connection string |
+| `STELLAR_NETWORK` | Leave as `testnet` |
+| `STELLAR_RPC_URL` | Leave as `https://soroban-testnet.stellar.org` |
+| `STELLAR_HORIZON_URL` | Leave as `https://horizon-testnet.stellar.org` |
+| `MARKET_FACTORY_CONTRACT_ID` | Output from Step 3 (MarketFactory deploy) |
+| `TREASURY_CONTRACT_ID` | Output from Step 3 (Treasury deploy) |
+| `ADMIN_SECRET_KEY` | Output from Step 2 (`stellar keys show admin`) |
+| `ADMIN_API_KEY` | Any secret string, e.g. `openssl rand -hex 32` |
+| `ORACLE_API_KEY` | Any secret string, e.g. `openssl rand -hex 32` |
+| `REDIS_URL` | `redis://localhost:6379` if running Redis locally |
+| `PORT` | Leave as `3001` |
+| `NODE_ENV` | Leave as `development` |
+
+---
+
+## 5 — Run database migrations
+
+```bash
+npm run db:migrate
+```
+
+This creates all tables (Markets, Bets, Disputes, OracleResults, etc.) in your PostgreSQL database.
+
+To verify the schema was applied:
+```bash
+npm run db:studio
+```
+
+This opens Prisma Studio at `http://localhost:5555` where you can browse the database tables.
+
+---
+
+## 6 — Start the server
+
+```bash
+npm run dev
+```
+
+You should see pretty-printed logs:
+```
+[INFO] boxmeout-backend listening on port 3001
+```
+
+Verify the server is healthy:
+```bash
+curl http://localhost:3001/health
+# {"status":"ok","db":"connected"}
+```
+
+---
+
+## Testnet Quick Start (TL;DR)
+
+```bash
+# 1. Accounts and funding
+stellar keys generate --global admin --network testnet
+stellar keys fund admin --network testnet
+
+# 2. Deploy contracts (from /contracts)
+cargo build --release --target wasm32-unknown-unknown
+stellar contract deploy --wasm target/wasm32-unknown-unknown/release/market_factory.wasm --source admin --network testnet
+stellar contract deploy --wasm target/wasm32-unknown-unknown/release/treasury.wasm --source admin --network testnet
+
+# 3. Configure and run (from /backend)
+cp .env.example .env  # fill in contract IDs and secret key
+npm install
+npm run db:migrate
+npm run dev
+```
+
+---
+
+## Running tests
+
+```bash
+npm test
+```
+
+Tests use mocked services and do not require a Stellar network connection or a running PostgreSQL instance (the test suite mocks the database layer).
+
+---
+
+## Troubleshooting
+
+**`DATABASE_URL` connection refused**
+Make sure PostgreSQL is running: `pg_isready -h localhost -p 5432`
+
+**`Error: account not found` from Stellar SDK**
+The admin account was not funded. Run `stellar keys fund admin --network testnet` again.
+
+**`MARKET_FACTORY_CONTRACT_ID` not set**
+The contract has not been deployed yet. Follow Step 3 above.
+
+**Friendbot rate-limited**
+Friendbot is a public Testnet faucet and may rate-limit requests. Wait a minute and retry.


### PR DESCRIPTION
- #915: Add src/logger.ts (Pino) with pino-pretty in dev, raw JSON in prod; add pino-http request middleware; replace console.log in lockMarkets job
- #916: Integration tests for all market API endpoints (GET /api/markets, /:id, /:id/stats, /:id/bets, /api/admin/markets/pending) with service mocks
- #917: Integration tests for bet endpoints (GET /api/bets/:address, /portfolio, /payout-estimate) including validation and 429 rate-limit case
closes #918 : Expand .env.example with per-variable inline comments; add docs/backend-setup.md step-by-step Testnet guide; add Testnet Quick Start section to root README.md
- Add src/app.ts Express factory, src/api/routes/admin.routes.ts, tsconfig.json, jest.config.ts; move admin routes out of market router to fix wildcard conflict
- Update .gitignore: add contracts/target/, .claude/settings.local.json, treasury_changes.txt
Closes #915 
Closes #916 
Closes #917 
Closes #918 