### PR TITLE
feat: full text market search

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/*.test.ts"],
+  globals: { "ts-jest": { tsconfig: { strict: false } } },
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
+    "@types/jest": "^29.0.0",
     "jest": "^29.0.0",
     "prisma": "^5.0.0",
     "ts-jest": "^29.0.0",

--- a/backend/prisma/migrations/20260626000000_add_market_search/migration.sql
+++ b/backend/prisma/migrations/20260626000000_add_market_search/migration.sql
@@ -1,0 +1,25 @@
+-- Add full-text search fields to Market
+ALTER TABLE "Market"
+  ADD COLUMN IF NOT EXISTS "question"    TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS "description" TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS "tsVector"    TSVECTOR;
+
+-- Populate tsvector for existing rows
+UPDATE "Market"
+SET "tsVector" = to_tsvector('english', "question" || ' ' || "description");
+
+-- Keep tsvector in sync via trigger
+CREATE OR REPLACE FUNCTION market_tsvector_update() RETURNS trigger AS $$
+BEGIN
+  NEW."tsVector" := to_tsvector('english', NEW."question" || ' ' || NEW."description");
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER market_tsvector_trigger
+  BEFORE INSERT OR UPDATE OF "question", "description"
+  ON "Market"
+  FOR EACH ROW EXECUTE FUNCTION market_tsvector_update();
+
+-- GIN index for fast full-text search
+CREATE INDEX IF NOT EXISTS "Market_tsVector_idx" ON "Market" USING GIN ("tsVector");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -35,6 +35,8 @@ model Market {
   contractAddress String       @unique
   fighterA        Json
   fighterB        Json
+  question        String       @default("")
+  description     String       @default("")
   scheduledAt     DateTime
   bettingEndsAt   DateTime
   createdAt       DateTime
@@ -50,6 +52,8 @@ model Market {
   bets            Bet[]
   disputes        Dispute[]
   oracleResult    OracleResult?
+  /// @db.Unsupported("tsvector")
+  tsVector        Unsupported("tsvector")?
 }
 
 model Bet {

--- a/backend/src/api/controllers/market.controller.ts
+++ b/backend/src/api/controllers/market.controller.ts
@@ -1,8 +1,22 @@
 import { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
 import * as marketService from "../../services/market.service";
+import { searchMarkets } from "../../repositories/market.repository";
 
 const prisma = new PrismaClient();
+
+/**
+ * GET /api/markets/search?q=&page=&limit=
+ * Full-text search across question + description. Returns paginated { data, total }.
+ */
+export async function searchMarketsHandler(req: Request, res: Response): Promise<void> {
+  const q = String(req.query.q ?? "").trim();
+  if (!q) { res.status(400).json({ error: "q is required" }); return; }
+  const page  = Math.max(1, parseInt(String(req.query.page  ?? "1"),  10) || 1);
+  const limit = Math.min(100, Math.max(1, parseInt(String(req.query.limit ?? "20"), 10) || 20));
+  const result = await searchMarkets(q, page, limit);
+  res.json(result);
+}
 
 /**
  * GET /api/markets

--- a/backend/src/api/routes/market.routes.ts
+++ b/backend/src/api/routes/market.routes.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import {
+  searchMarketsHandler,
   getMarketsHandler,
   getMarketByIdHandler,
   getMarketStatsHandler,
@@ -12,6 +13,7 @@ import {
 const router = Router();
 
 // Public
+router.get("/search", searchMarketsHandler);   // must be before /:id
 router.get("/", getMarketsHandler);
 router.get("/:id", getMarketByIdHandler);
 router.get("/:id/stats", getMarketStatsHandler);

--- a/backend/src/repositories/market.repository.test.ts
+++ b/backend/src/repositories/market.repository.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Integration test: GET /markets/search
+ *
+ * Mocks Prisma $queryRaw and ioredis so no real DB/Redis is required.
+ */
+
+// ── Prisma mock ──────────────────────────────────────────────────────────────
+const mockQueryRaw = jest.fn();
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({ $queryRaw: mockQueryRaw })),
+}));
+
+// ── ioredis mock ─────────────────────────────────────────────────────────────
+const mockGet    = jest.fn().mockResolvedValue(null);
+const mockSetex  = jest.fn().mockResolvedValue("OK");
+jest.mock("ioredis", () =>
+  jest.fn().mockImplementation(() => ({ get: mockGet, setex: mockSetex }))
+);
+
+import { searchMarkets } from "../src/repositories/market.repository";
+
+const MARKET = {
+  id: "mkt-1",
+  contractAddress: "0xabc",
+  question: "Will Fury beat Wilder?",
+  description: "Heavyweight championship bout",
+  tsVector: null,
+};
+
+describe("searchMarkets()", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns matching market when query is relevant", async () => {
+    // First call → rows, second call → count
+    mockQueryRaw
+      .mockResolvedValueOnce([{ ...MARKET, rank: 0.9 }])
+      .mockResolvedValueOnce([{ count: BigInt(1) }]);
+
+    const result = await searchMarkets("Fury", 1, 20);
+
+    expect(result.total).toBe(1);
+    expect(result.data).toHaveLength(1);
+    expect((result.data[0] as typeof MARKET).id).toBe("mkt-1");
+  });
+
+  it("returns empty when query is irrelevant", async () => {
+    mockQueryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ count: BigInt(0) }]);
+
+    const result = await searchMarkets("chess", 1, 20);
+
+    expect(result.total).toBe(0);
+    expect(result.data).toHaveLength(0);
+  });
+
+  it("returns cached result without hitting DB on second call", async () => {
+    const cached = JSON.stringify({ data: [MARKET], total: 1 });
+    mockGet.mockResolvedValueOnce(cached);
+
+    const result = await searchMarkets("Fury", 1, 20);
+
+    expect(mockQueryRaw).not.toHaveBeenCalled();
+    expect(result.total).toBe(1);
+  });
+
+  it("caches the result after a DB hit", async () => {
+    mockQueryRaw
+      .mockResolvedValueOnce([MARKET])
+      .mockResolvedValueOnce([{ count: BigInt(1) }]);
+
+    await searchMarkets("Wilder", 1, 20);
+
+    expect(mockSetex).toHaveBeenCalledWith(
+      "search:Wilder:1:20",
+      10,
+      expect.any(String)
+    );
+  });
+});

--- a/backend/src/repositories/market.repository.ts
+++ b/backend/src/repositories/market.repository.ts
@@ -1,0 +1,51 @@
+import { PrismaClient } from "@prisma/client";
+import Redis from "ioredis";
+
+const prisma = new PrismaClient();
+const redis = new Redis(process.env.REDIS_URL ?? "redis://localhost:6379");
+
+const CACHE_TTL = 10; // seconds
+
+export interface SearchResult {
+  data: Record<string, unknown>[];
+  total: number;
+}
+
+/**
+ * Full-text search across question + description using tsvector.
+ * Results are sorted by relevance and cached in Redis for 10 s.
+ */
+export async function searchMarkets(
+  q: string,
+  page = 1,
+  limit = 20
+): Promise<SearchResult> {
+  const cacheKey = `search:${q}:${page}:${limit}`;
+  const cached = await redis.get(cacheKey);
+  if (cached) return JSON.parse(cached) as SearchResult;
+
+  const offset = (page - 1) * limit;
+
+  const [rows, countRows] = await Promise.all([
+    prisma.$queryRaw<Record<string, unknown>[]>`
+      SELECT *, ts_rank("tsVector", plainto_tsquery('english', ${q})) AS rank
+      FROM "Market"
+      WHERE "tsVector" @@ plainto_tsquery('english', ${q})
+      ORDER BY rank DESC
+      LIMIT ${limit} OFFSET ${offset}
+    `,
+    prisma.$queryRaw<[{ count: bigint }]>`
+      SELECT COUNT(*)::bigint AS count
+      FROM "Market"
+      WHERE "tsVector" @@ plainto_tsquery('english', ${q})
+    `,
+  ]);
+
+  const result: SearchResult = {
+    data: rows,
+    total: Number(countRows[0].count),
+  };
+
+  await redis.setex(cacheKey, CACHE_TTL, JSON.stringify(result));
+  return result;
+}


### PR DESCRIPTION
  
  What changed:
  
  - prisma/schema.prisma — added question, description, and tsVector (tsvector) fields to Market
  - prisma/migrations/20260626000000_add_market_search/migration.sql — alters table to add the new columns, a trigger to auto-update tsVector on insert/update, and
  a GIN index for fast full-text search
  - src/repositories/market.repository.ts — searchMarkets(q, page, limit) runs a ranked plainto_tsquery search via raw SQL, returns { data, total }, and caches
  results in Redis for 10 seconds per unique query+page+limit key
  - src/api/controllers/market.controller.ts — searchMarketsHandler parses and validates q, page, limit query params and delegates to the repository
  - src/api/routes/market.routes.ts — registers GET /markets/search as a public route before /:id to prevent the param route from capturing it
  - jest.config.js + src/repositories/market.repository.test.ts — four unit/integration tests covering: match found, no match, cache hit (DB not called), and cache
  write after DB hit

closes #454 