### PR TITLE
implement getAllMarkets service

### DIFF
--- a/backend/src/services/market.service.ts
+++ b/backend/src/services/market.service.ts
@@ -1,4 +1,6 @@
-import { Market, MarketStatus, Outcome } from "@prisma/client";
+import { Market, MarketStatus, Outcome, PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
 
 export interface MarketFilters {
   status?: MarketStatus;
@@ -47,7 +49,19 @@ export async function getAllMarkets(
   filters?: MarketFilters,
   pagination?: Pagination
 ): Promise<Market[]> {
-  throw new Error("Not implemented");
+  const where: { status?: MarketStatus; weightClass?: string } = {};
+  if (filters?.status) where.status = filters.status;
+  if (filters?.weightClass) where.weightClass = filters.weightClass;
+
+  const page = pagination?.page ?? 1;
+  const limit = pagination?.limit ?? 20;
+
+  return prisma.market.findMany({
+    where,
+    orderBy: { scheduledAt: "asc" },
+    skip: (page - 1) * limit,
+    take: limit,
+  });
 }
 
 /**


### PR DESCRIPTION
 Implements the getAllMarkets function with filter and pagination support.
  
  Changes:
  
  - Added weightClass field to the Market model in prisma/schema.prisma
  - Implemented getAllMarkets in market.service.ts — builds a Prisma where clause from optional status and weightClass filters, applies skip/take pagination, and
  orders results by scheduledAt ascending
  - Added jest.config.ts and tsconfig.json to enable the test suite
  - Added integration test in src/services/__tests__/market.service.test.ts covering: no filters returns all markets, status filter returns only matching markets,
  pagination returns correct slices, no matches returns empty array
  
  Testing:
  
  All integration tests pass against a seeded test database.

closes #881 