### PR TITLE
implement createMarketRecord

### DIFF
--- a/backend/src/lib/db.ts
+++ b/backend/src/lib/db.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from "@prisma/client";
+
+const db = new PrismaClient();
+
+export default db;

--- a/backend/src/services/market.service.ts
+++ b/backend/src/services/market.service.ts
@@ -1,4 +1,5 @@
 import { Market, MarketStatus, Outcome } from "@prisma/client";
+import db from "../lib/db";
 
 export interface MarketFilters {
   status?: MarketStatus;
@@ -66,7 +67,23 @@ export async function getMarketById(market_id: string): Promise<Market | null> {
 export async function createMarketRecord(
   marketData: CreateMarketDTO
 ): Promise<Market> {
-  throw new Error("Not implemented");
+  const data = {
+    contractAddress: marketData.contractAddress,
+    fighterA: marketData.fighterA,
+    fighterB: marketData.fighterB,
+    scheduledAt: marketData.scheduledAt,
+    bettingEndsAt: marketData.bettingEndsAt,
+    createdAt: marketData.createdAt,
+    createdBy: marketData.createdBy,
+    oracleAddress: marketData.oracleAddress,
+    txHash: marketData.txHash,
+  };
+
+  return db.market.upsert({
+    where: { id: marketData.id },
+    create: { id: marketData.id, ...data },
+    update: {},
+  });
 }
 
 /**


### PR DESCRIPTION
  Here's a description of the fix:
  
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Idempotent createMarketRecord using db.market.upsert()
  
  The createMarketRecord function in market.service.ts was a stub throwing "Not implemented". The fix implements it using Prisma's upsert so that calling it
  multiple times with the same market ID is safe — matching the event replay requirement of the indexer.
  
  What was done:
  
  - Created src/lib/db.ts — a shared singleton PrismaClient instance imported across services.
  - Replaced the stub in createMarketRecord with db.market.upsert():
    - where: { id } — targets the record by its on-chain market ID.
    - create — maps all CreateMarketDTO fields to the Prisma Market model on first call.
    - update: {} — no-op on subsequent calls, making it fully idempotent.
  
  Why this matters:
  
  The indexer replays blockchain events on restarts or missed ledgers. Without idempotency, replaying a MarketCreated event would either throw a unique constraint
  error or create a duplicate. With upsert, the first call creates the record and every subsequent call with the same ID is a silent no-op — no error, no duplicate.
closes #883 