### PR TITLE
feat: implement issues #907-#910 admin auth, oracle submit, resolve, portfolio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,14 @@ backend/src/generated/
 # Temp files
 *.tmp
 *.swp
+
+# ─── Claude / AI tooling ─────────────────────────────────────
+.claude/
+
+# ─── Compiled output (scoped) ────────────────────────────────
+backend/dist/
+backend/build/
+frontend/dist/
+frontend/build/
+indexer/dist/
+indexer/build/

--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  rootDir: ".",
+  testMatch: ["**/__tests__/**/*.test.ts", "**/tests/**/*.test.ts"],
+  moduleFileExtensions: ["ts", "js", "json"],
+};
+
+export default config;

--- a/backend/src/api/controllers/bet.controller.ts
+++ b/backend/src/api/controllers/bet.controller.ts
@@ -1,4 +1,5 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
+import * as betService from "../../services/bet.service";
 
 /**
  * GET /api/bets/:address
@@ -10,11 +11,29 @@ export async function getBetsByAddressHandler(req: Request, res: Response): Prom
 }
 
 /**
- * GET /api/bets/:address/portfolio
+ * GET /api/bets/:address/portfolio (issue #907)
  * Returns portfolio summary (total staked, winnings, ROI) for an address.
+ * Returns zero-value summary (never 404) for unknown addresses.
  */
-export async function getPortfolioHandler(req: Request, res: Response): Promise<void> {
-  throw new Error("Not implemented");
+export async function getPortfolioHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { address } = req.params;
+
+    // Basic Stellar public key validation (G..., 56 chars, base32)
+    if (typeof address !== "string" || !address.startsWith("G") || address.length !== 56) {
+      res.status(400).json({ error: "Invalid Stellar address format", code: "VALIDATION_ERROR" });
+      return;
+    }
+
+    const portfolio = await betService.getPortfolioSummary(address);
+    res.status(200).json(portfolio);
+  } catch (err) {
+    next(err);
+  }
 }
 
 /**

--- a/backend/src/api/controllers/market.controller.ts
+++ b/backend/src/api/controllers/market.controller.ts
@@ -1,6 +1,7 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { PrismaClient } from "@prisma/client";
 import * as marketService from "../../services/market.service";
+import * as oracleService from "../../services/oracle.service";
 
 const prisma = new PrismaClient();
 
@@ -38,12 +39,31 @@ export async function getMarketBetsHandler(req: Request, res: Response): Promise
 }
 
 /**
- * POST /api/admin/markets/resolve
- * Body: { market_id, outcome, source }
- * Admin-protected. Submits oracle result and triggers on-chain resolution.
+ * POST /api/admin/markets/resolve (issue #909)
+ * Body: { oracle_result_id: number }
+ * Admin-protected (adminAuth middleware). Confirms an oracle result and
+ * triggers on-chain market resolution. Returns 200 { status: 'ok' }.
  */
-export async function resolveMarketHandler(req: Request, res: Response): Promise<void> {
-  throw new Error("Not implemented");
+export async function resolveMarketHandler(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const { oracle_result_id } = req.body;
+
+    if (oracle_result_id === undefined || oracle_result_id === null) {
+      res.status(400).json({ error: "oracle_result_id is required", code: "VALIDATION_ERROR" });
+      return;
+    }
+
+    const id = Number(oracle_result_id);
+    if (!Number.isInteger(id) || id <= 0) {
+      res.status(400).json({ error: "oracle_result_id must be a positive integer", code: "VALIDATION_ERROR" });
+      return;
+    }
+
+    await oracleService.confirmFightResult(String(id), "admin");
+    res.status(200).json({ status: "ok" });
+  } catch (err) {
+    next(err);
+  }
 }
 
 /**

--- a/backend/src/api/controllers/oracle.controller.ts
+++ b/backend/src/api/controllers/oracle.controller.ts
@@ -1,14 +1,67 @@
-import { Request, Response } from "express";
+import { timingSafeEqual } from "crypto";
+import { Request, Response, NextFunction } from "express";
 import * as oracleService from "../../services/oracle.service";
 
+// ---------------------------------------------------------------------------
+// Timing-safe Bearer token check for ORACLE_API_KEY
+// ---------------------------------------------------------------------------
+function checkOracleAuth(req: Request): boolean {
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith("Bearer ")) return false;
+
+  const provided = authHeader.slice(7);
+  const expected = process.env.ORACLE_API_KEY ?? "";
+  if (!expected) return false;
+
+  try {
+    const a = Buffer.from(provided);
+    const b = Buffer.from(expected);
+    const len = Math.max(a.length, b.length);
+    const bufA = Buffer.alloc(len);
+    const bufB = Buffer.alloc(len);
+    a.copy(bufA);
+    b.copy(bufB);
+    return timingSafeEqual(bufA, bufB) && a.length === b.length;
+  } catch {
+    return false;
+  }
+}
+
 /**
- * POST /api/oracle/submit
+ * POST /api/oracle/submit (issue #908)
+ * Header: Authorization: Bearer <ORACLE_API_KEY>
  * Body: { market_id, outcome, source }
- * Authorized oracle nodes submit fight results here.
- * Validates Authorization header before processing.
+ *
+ * Returns 401 if auth fails, 400 if body invalid, 201 with OracleResult on success.
  */
-export async function submitOracleResultHandler(req: Request, res: Response): Promise<void> {
-  throw new Error("Not implemented");
+export async function submitOracleResultHandler(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    if (!checkOracleAuth(req)) {
+      res.status(401).json({ error: "Unauthorized", code: "UNAUTHORIZED" });
+      return;
+    }
+
+    const { market_id, outcome, source } = req.body as {
+      market_id: string;
+      outcome: string;
+      source: string;
+    };
+
+    const result = await oracleService.submitFightResult(
+      market_id,
+      outcome as Parameters<typeof oracleService.submitFightResult>[1],
+      source,
+      "oracle",
+    );
+
+    res.status(201).json(result);
+  } catch (err) {
+    next(err);
+  }
 }
 
 /**

--- a/backend/src/api/middleware/adminAuth.ts
+++ b/backend/src/api/middleware/adminAuth.ts
@@ -1,0 +1,44 @@
+import { timingSafeEqual } from "crypto";
+import type { Request, Response, NextFunction } from "express";
+
+/**
+ * Middleware — validates Authorization: Bearer <ADMIN_API_KEY> header.
+ * Uses crypto.timingSafeEqual to prevent timing attacks.
+ * Returns 401 { error, code } on any failure.
+ */
+export function adminAuth(req: Request, res: Response, next: NextFunction): void {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader?.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Unauthorized", code: "UNAUTHORIZED" });
+    return;
+  }
+
+  const provided = authHeader.slice(7);
+  const expected = process.env.ADMIN_API_KEY ?? "";
+
+  if (!expected) {
+    res.status(401).json({ error: "Unauthorized", code: "UNAUTHORIZED" });
+    return;
+  }
+
+  try {
+    const a = Buffer.from(provided);
+    const b = Buffer.from(expected);
+    const len = Math.max(a.length, b.length);
+    const bufA = Buffer.alloc(len);
+    const bufB = Buffer.alloc(len);
+    a.copy(bufA);
+    b.copy(bufB);
+
+    if (!timingSafeEqual(bufA, bufB) || a.length !== b.length) {
+      res.status(401).json({ error: "Unauthorized", code: "UNAUTHORIZED" });
+      return;
+    }
+  } catch {
+    res.status(401).json({ error: "Unauthorized", code: "UNAUTHORIZED" });
+    return;
+  }
+
+  next();
+}

--- a/backend/src/api/routes/market.routes.ts
+++ b/backend/src/api/routes/market.routes.ts
@@ -8,6 +8,7 @@ import {
   resolveDisputeHandler,
   getPendingResolutionsHandler,
 } from "../controllers/market.controller";
+import { adminAuth } from "../middleware/adminAuth";
 
 const router = Router();
 
@@ -17,9 +18,9 @@ router.get("/:id", getMarketByIdHandler);
 router.get("/:id/stats", getMarketStatsHandler);
 router.get("/:id/bets", getMarketBetsHandler);
 
-// Admin
-router.post("/admin/markets/resolve", resolveMarketHandler);
-router.post("/admin/markets/dispute/resolve", resolveDisputeHandler);
-router.get("/admin/markets/pending", getPendingResolutionsHandler);
+// Admin — protected by Bearer ADMIN_API_KEY (issue #909/#910)
+router.post("/admin/markets/resolve", adminAuth, resolveMarketHandler);
+router.post("/admin/markets/dispute/resolve", adminAuth, resolveDisputeHandler);
+router.get("/admin/markets/pending", adminAuth, getPendingResolutionsHandler);
 
 export default router;

--- a/backend/src/api/routes/oracle.routes.ts
+++ b/backend/src/api/routes/oracle.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { submitOracleResultHandler, listOracleResultsHandler } from "../controllers/oracle.controller";
+
+const router = Router();
+
+// POST /api/oracle/submit — Bearer ORACLE_API_KEY, returns 201 (issue #908)
+router.post("/submit", submitOracleResultHandler);
+
+// GET /api/oracle/results — admin view of all submitted results
+router.get("/results", listOracleResultsHandler);
+
+export default router;

--- a/backend/tests/issues-907-908-909-910.test.ts
+++ b/backend/tests/issues-907-908-909-910.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for issues #907, #908, #909, #910.
+ * Mocks the service layer and exercises controller behaviour.
+ */
+
+import type { Request, Response, NextFunction } from "express";
+
+// ─── Mock services ───────────────────────────────────────────────────────────
+
+jest.mock("../../src/services/oracle.service", () => ({
+  submitFightResult: jest.fn(),
+  confirmFightResult: jest.fn(),
+}));
+
+jest.mock("../../src/services/bet.service", () => ({
+  getPortfolioSummary: jest.fn(),
+}));
+
+import * as oracleService from "../../src/services/oracle.service";
+import * as betService from "../../src/services/bet.service";
+
+import { submitOracleResultHandler } from "../../src/api/controllers/oracle.controller";
+import { getPortfolioHandler } from "../../src/api/controllers/bet.controller";
+import { resolveMarketHandler } from "../../src/api/controllers/market.controller";
+import { adminAuth } from "../../src/api/middleware/adminAuth";
+
+const ORACLE_KEY = "oracle-secret";
+const ADMIN_KEY = "admin-secret";
+
+function mockRes() {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  return { res: { status, json } as unknown as Response, status, json };
+}
+
+// ─── #910 adminAuth middleware ───────────────────────────────────────────────
+
+describe("#910 adminAuth middleware", () => {
+  beforeEach(() => {
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+  });
+
+  it("calls next() with correct Bearer key", () => {
+    const req = { headers: { authorization: `Bearer ${ADMIN_KEY}` } } as unknown as Request;
+    const { res } = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+    adminAuth(req, res, next);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("returns 401 when Authorization header is missing", () => {
+    const req = { headers: {} } as unknown as Request;
+    const { res, status, json } = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+    adminAuth(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ error: "Unauthorized", code: "UNAUTHORIZED" });
+  });
+
+  it("returns 401 when key is wrong", () => {
+    const req = { headers: { authorization: "Bearer wrong-key" } } as unknown as Request;
+    const { res, status, json } = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+    adminAuth(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ error: "Unauthorized", code: "UNAUTHORIZED" });
+  });
+
+  it("returns 401 when Bearer prefix is missing", () => {
+    const req = { headers: { authorization: ADMIN_KEY } } as unknown as Request;
+    const { res, status } = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+    adminAuth(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+  });
+});
+
+// ─── #908 submitOracleResultHandler ─────────────────────────────────────────
+
+describe("#908 submitOracleResultHandler", () => {
+  const validBody = { market_id: "fight-1", outcome: "fighter_a", source: "boxing-api" };
+
+  beforeEach(() => {
+    process.env.ORACLE_API_KEY = ORACLE_KEY;
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const req = { headers: {}, body: validBody } as unknown as Request;
+    const { res, status, json } = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+    await submitOracleResultHandler(req, res, next);
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ error: "Unauthorized", code: "UNAUTHORIZED" });
+  });
+
+  it("returns 401 when wrong API key is provided", async () => {
+    const req = {
+      headers: { authorization: "Bearer wrong-key" },
+      body: validBody,
+    } as unknown as Request;
+    const { res, status, json } = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+    await submitOracleResultHandler(req, res, next);
+    expect(status).toHaveBeenCalledWith(401);
+    expect(json).toHaveBeenCalledWith({ error: "Unauthorized", code: "UNAUTHORIZED" });
+  });
+
+  it("returns 201 with OracleResult on valid submission", async () => {
+    const fakeResult = { id: 1, market_id: "fight-1", outcome: "fighter_a", source: "boxing-api" };
+    (oracleService.submitFightResult as jest.Mock).mockResolvedValue(fakeResult);
+
+    const req = {
+      headers: { authorization: `Bearer ${ORACLE_KEY}` },
+      body: validBody,
+    } as unknown as Request;
+    const { res, status, json } = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await submitOracleResultHandler(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(201);
+    expect(json).toHaveBeenCalledWith(fakeResult);
+  });
+});
+
+// ─── #907 getPortfolioHandler ────────────────────────────────────────────────
+
+const VALID_STELLAR = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
+describe("#907 getPortfolioHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 400 for invalid Stellar address", async () => {
+    const req = { params: { address: "invalid" } } as unknown as Request;
+    const { res, status, json } = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await getPortfolioHandler(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "VALIDATION_ERROR" }),
+    );
+  });
+
+  it("returns 200 with portfolio for a valid address", async () => {
+    const portfolio = {
+      totalStaked: BigInt(0),
+      totalWinnings: BigInt(0),
+      pendingClaims: BigInt(0),
+      activeBets: 0,
+      completedBets: 0,
+      roi: 0,
+    };
+    (betService.getPortfolioSummary as jest.Mock).mockResolvedValue(portfolio);
+
+    const req = { params: { address: VALID_STELLAR } } as unknown as Request;
+    const { res, status, json } = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await getPortfolioHandler(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith(portfolio);
+  });
+});
+
+// ─── #909 resolveMarketHandler ───────────────────────────────────────────────
+
+describe("#909 resolveMarketHandler", () => {
+  beforeEach(() => {
+    process.env.ADMIN_API_KEY = ADMIN_KEY;
+    jest.clearAllMocks();
+  });
+
+  it("returns 400 when oracle_result_id is missing", async () => {
+    const req = { body: {} } as unknown as Request;
+    const { res, status, json } = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await resolveMarketHandler(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "VALIDATION_ERROR" }),
+    );
+  });
+
+  it("returns 400 when oracle_result_id is not a positive integer", async () => {
+    const req = { body: { oracle_result_id: -1 } } as unknown as Request;
+    const { res, status, json } = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await resolveMarketHandler(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(400);
+  });
+
+  it("returns 200 { status: ok } on valid call", async () => {
+    (oracleService.confirmFightResult as jest.Mock).mockResolvedValue(undefined);
+
+    const req = { body: { oracle_result_id: 42 } } as unknown as Request;
+    const { res, status, json } = mockRes();
+    const next = jest.fn() as unknown as NextFunction;
+
+    await resolveMarketHandler(req, res, next);
+
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({ status: "ok" });
+    expect(oracleService.confirmFightResult).toHaveBeenCalledWith("42", "admin");
+  });
+});


### PR DESCRIPTION
Add adminAuth middleware with timing-safe Bearer ADMIN_API_KEY check
 Add resolveMarketHandler (POST /api/admin/markets/resolve)
 Add submitOracleResultHandler (POST /api/oracle/submit, Bearer auth, 201)
 Add getPortfolioHandler (GET /api/bets/:address/portfolio)
- Wire oracleRouter and betRouter into index.ts
- Remove duplicate getBetsByAddress from MarketService
- Add tests for all four issues
- Update .gitignore
Closes #910 
Closes #909 
Closes #908 
Closes #907 