### PR TITLE
feat(oracle): implement verifyOracleAuthorization and pollExternalRes…

### DIFF
--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -5,7 +5,11 @@ const config: Config = {
   testEnvironment: "node",
   rootDir: ".",
   roots: ["<rootDir>/src", "<rootDir>/__tests__", "<rootDir>/tests"],
-  testMatch: ["**/__tests__/**/*.test.ts", "**/tests/**/*.test.ts", "**/*.test.ts"],
+  testMatch: [
+    "**/__tests__/**/*.test.ts",
+    "**/tests/**/*.test.ts",
+    "**/*.test.ts",
+  ],
   moduleFileExtensions: ["ts", "js", "json"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
@@ -17,15 +21,6 @@ const config: Config = {
     "!src/**/*.d.ts",
     "!src/**/index.ts",
   ],
-  roots: ["<rootDir>/__tests__", "<rootDir>/src"],
-  testMatch: ["**/__tests__/**/*.test.ts", "**/*.test.ts", "**/tests/**/*.test.ts"],
-  moduleFileExtensions: ["ts", "js", "json"],
-  clearMocks: true,
-  restoreMocks: true,
-  rootDir: ".",
-  moduleNameMapper: {
-    "^@/(.*)$": "<rootDir>/src/$1",
-  },
 };
 
 export default config;

--- a/backend/src/services/__tests__/oracle.service.b22-b24.test.ts
+++ b/backend/src/services/__tests__/oracle.service.b22-b24.test.ts
@@ -1,0 +1,547 @@
+/**
+ * Unit tests for B-22 / #1080 — verifyOracleAuthorization
+ *          and B-24 / #1082 — pollExternalResultFeeds
+ *
+ * All external dependencies (PrismaClient, logger, Stellar SDK) are fully
+ * mocked, so no real database or network connections are required.
+ */
+
+// ── Mock logger ────────────────────────────────────────────────────────────
+jest.mock("../../logger", () => ({
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+// ── Mock @stellar/stellar-sdk to avoid loading the heavy SDK ──────────────
+jest.mock("@stellar/stellar-sdk", () => ({
+  SorobanRpc: { Server: jest.fn() },
+  TransactionBuilder: jest.fn(),
+  Networks: { PUBLIC: "Public Global Stellar Network ; September 2015", TESTNET: "Test SDF Network ; September 2015" },
+  Contract: jest.fn(),
+  Keypair: { fromSecret: jest.fn() },
+  BASE_FEE: "100",
+  nativeToScVal: jest.fn(),
+  xdr: { ScVal: { scvSymbol: jest.fn() } },
+}));
+
+// ── PrismaClient mocks ─────────────────────────────────────────────────────
+// We keep individual jest.fn() references so each test can configure them.
+const mockMarketFindUnique = jest.fn();
+const mockMarketFindMany = jest.fn();
+const mockOracleFindFirst = jest.fn();
+const mockOracleResultFindUnique = jest.fn();
+const mockOracleResultCreate = jest.fn();
+
+jest.mock("@prisma/client", () => {
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => ({
+      market: {
+        findUnique: mockMarketFindUnique,
+        findMany: mockMarketFindMany,
+      },
+      oracle: {
+        findFirst: mockOracleFindFirst,
+        findMany: jest.fn(),
+        findUnique: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+      },
+      oracleResult: {
+        findUnique: mockOracleResultFindUnique,
+        create: mockOracleResultCreate,
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      dispute: { create: jest.fn() },
+      adminLog: { create: jest.fn() },
+      $transaction: jest.fn(),
+    })),
+    // Re-export enums / types the module-under-test imports at the type level
+    Prisma: {},
+  };
+});
+
+// ── Import after mocks are registered ─────────────────────────────────────
+import {
+  verifyOracleAuthorization,
+  OracleAuthorizationError,
+  pollExternalResultFeeds,
+  FeedSource,
+  CandidateResolution,
+  ExternalFightResult,
+} from "../oracle.service";
+import { PrismaClient } from "@prisma/client";
+import { logger } from "../../logger";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makePrisma(): PrismaClient {
+  return new PrismaClient();
+}
+
+function makeExternalResult(
+  overrides: Partial<ExternalFightResult> = {},
+): ExternalFightResult {
+  return {
+    matchId: "match-001",
+    winner: "FighterA",
+    method: "KO",
+    round: 3,
+    source: "https://api.boxrec.com",
+    reportedAt: new Date("2026-07-10T22:00:00Z"),
+    ...overrides,
+  };
+}
+
+function makeMarket(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "market-abc",
+    contractAddress: "CCONTRACT1",
+    oracleAddress: "GORACLE1",
+    status: "Locked",
+    scheduledAt: new Date("2026-07-10T20:00:00Z"),
+    fighterA: { name: "Fighter A" },
+    fighterB: { name: "Fighter B" },
+    ...overrides,
+  };
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// B-22 / #1080 — verifyOracleAuthorization
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("B-22 / #1080 — verifyOracleAuthorization", () => {
+  let db: PrismaClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    db = makePrisma();
+  });
+
+  // ── Happy paths ────────────────────────────────────────────────────────
+
+  it("resolves without error when submitter matches the market oracleAddress", async () => {
+    mockMarketFindUnique.mockResolvedValueOnce(
+      makeMarket({ oracleAddress: "GORACLE1" }),
+    );
+
+    await expect(
+      verifyOracleAuthorization("market-abc", "GORACLE1", db),
+    ).resolves.toBeUndefined();
+  });
+
+  it("resolves without error when submitter is a globally registered active oracle", async () => {
+    // Market has a DIFFERENT oracleAddress, but submitter is in the Oracle table.
+    mockMarketFindUnique.mockResolvedValueOnce(
+      makeMarket({ oracleAddress: "GORACLE_SPECIFIC" }),
+    );
+    mockOracleFindFirst.mockResolvedValueOnce({
+      id: "oid-1",
+      address: "GORACLE_GLOBAL",
+      active: true,
+    });
+
+    await expect(
+      verifyOracleAuthorization("market-abc", "GORACLE_GLOBAL", db),
+    ).resolves.toBeUndefined();
+  });
+
+  // ── Mismatch / rejection ───────────────────────────────────────────────
+
+  it("throws OracleAuthorizationError when submitter does not match and is not registered", async () => {
+    mockMarketFindUnique.mockResolvedValueOnce(
+      makeMarket({ oracleAddress: "GORACLE_CORRECT" }),
+    );
+    // No registered oracle for the bad submitter
+    mockOracleFindFirst.mockResolvedValueOnce(null);
+
+    await expect(
+      verifyOracleAuthorization("market-abc", "GORACLE_WRONG", db),
+    ).rejects.toThrow(OracleAuthorizationError);
+  });
+
+  it("OracleAuthorizationError carries expected, actual, and marketId", async () => {
+    mockMarketFindUnique.mockResolvedValueOnce(
+      makeMarket({ oracleAddress: "GORACLE_CORRECT" }),
+    );
+    mockOracleFindFirst.mockResolvedValueOnce(null);
+
+    let caught: OracleAuthorizationError | undefined;
+    try {
+      await verifyOracleAuthorization("market-abc", "GORACLE_WRONG", db);
+    } catch (err) {
+      caught = err as OracleAuthorizationError;
+    }
+
+    expect(caught).toBeDefined();
+    expect(caught!.name).toBe("OracleAuthorizationError");
+    expect(caught!.marketId).toBe("market-abc");
+    expect(caught!.expected).toBe("GORACLE_CORRECT");
+    expect(caught!.actual).toBe("GORACLE_WRONG");
+    expect(caught!.message).toMatch("GORACLE_CORRECT");
+    expect(caught!.message).toMatch("GORACLE_WRONG");
+  });
+
+  it("throws OracleAuthorizationError even when a registered-but-inactive oracle tries to submit", async () => {
+    mockMarketFindUnique.mockResolvedValueOnce(
+      makeMarket({ oracleAddress: "GORACLE_CORRECT" }),
+    );
+    // findFirst filters by active: true, so an inactive oracle returns null
+    mockOracleFindFirst.mockResolvedValueOnce(null);
+
+    await expect(
+      verifyOracleAuthorization("market-abc", "GORACLE_INACTIVE", db),
+    ).rejects.toThrow(OracleAuthorizationError);
+  });
+
+  // ── Not-found path ─────────────────────────────────────────────────────
+
+  it("throws a plain Error when the market does not exist", async () => {
+    mockMarketFindUnique.mockResolvedValueOnce(null);
+
+    await expect(
+      verifyOracleAuthorization("no-such-market", "GORACLE1", db),
+    ).rejects.toThrow("Market not found: no-such-market");
+  });
+
+  it("does NOT call oracle.findFirst when market oracleAddress already matches", async () => {
+    mockMarketFindUnique.mockResolvedValueOnce(
+      makeMarket({ oracleAddress: "GORACLE1" }),
+    );
+
+    await verifyOracleAuthorization("market-abc", "GORACLE1", db);
+
+    expect(mockOracleFindFirst).not.toHaveBeenCalled();
+  });
+
+  // ── Dependency injection ───────────────────────────────────────────────
+
+  it("uses the injected db instead of the module-level prisma instance", async () => {
+    mockMarketFindUnique.mockResolvedValueOnce(
+      makeMarket({ oracleAddress: "GORACLE1" }),
+    );
+
+    await verifyOracleAuthorization("market-abc", "GORACLE1", db);
+
+    // The injected db.market.findUnique was called, not any module-level instance.
+    expect(mockMarketFindUnique).toHaveBeenCalledWith({
+      where: { id: "market-abc" },
+    });
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════════════════
+// B-24 / #1082 — pollExternalResultFeeds
+// ══════════════════════════════════════════════════════════════════════════════
+
+describe("B-24 / #1082 — pollExternalResultFeeds", () => {
+  let db: PrismaClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    db = makePrisma();
+  });
+
+  // ── Helper: build a minimal feed ────────────────────────────────────────
+  function makeFeed(
+    name: string,
+    result: ExternalFightResult | null,
+  ): FeedSource {
+    return { name, fetch: jest.fn().mockResolvedValue(result) };
+  }
+
+  // ── Happy path: single result queued ────────────────────────────────────
+
+  it("creates an unconfirmed OracleResult when a feed returns a result", async () => {
+    const market = makeMarket();
+    mockMarketFindMany.mockResolvedValueOnce([market]);
+    mockOracleResultFindUnique.mockResolvedValueOnce(null); // no existing candidate
+    mockOracleResultCreate.mockResolvedValueOnce({
+      id: "oresult-1",
+      marketId: market.id,
+      confirmed: false,
+    });
+
+    const feed = makeFeed("BoxRec", makeExternalResult());
+    const result = await pollExternalResultFeeds({ feeds: [feed], db });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].marketId).toBe(market.id);
+    expect(result[0].oracleResultId).toBe("oresult-1");
+  });
+
+  it("always creates OracleResult with confirmed = false (never auto-confirms)", async () => {
+    const market = makeMarket();
+    mockMarketFindMany.mockResolvedValueOnce([market]);
+    mockOracleResultFindUnique.mockResolvedValueOnce(null);
+    mockOracleResultCreate.mockResolvedValueOnce({
+      id: "oresult-2",
+      marketId: market.id,
+      confirmed: false,
+    });
+
+    const feed = makeFeed("ESPN", makeExternalResult({ winner: "FighterB" }));
+    await pollExternalResultFeeds({ feeds: [feed], db });
+
+    expect(mockOracleResultCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ confirmed: false }),
+      }),
+    );
+  });
+
+  it("maps winner correctly to DB Outcome enum value", async () => {
+    const market = makeMarket();
+    mockMarketFindMany.mockResolvedValueOnce([market]);
+    mockOracleResultFindUnique.mockResolvedValueOnce(null);
+    mockOracleResultCreate.mockResolvedValueOnce({ id: "oresult-3", marketId: market.id, confirmed: false });
+
+    const feed = makeFeed("BoxRec", makeExternalResult({ winner: "Draw" }));
+    await pollExternalResultFeeds({ feeds: [feed], db });
+
+    expect(mockOracleResultCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ outcome: "Draw" }),
+      }),
+    );
+  });
+
+  // ── No result available ───────────────────────────────────────────────────
+
+  it("returns an empty array when no feed has a result", async () => {
+    mockMarketFindMany.mockResolvedValueOnce([makeMarket()]);
+    mockOracleResultFindUnique.mockResolvedValueOnce(null);
+
+    const feed = makeFeed("BoxRec", null);
+    const result = await pollExternalResultFeeds({ feeds: [feed], db });
+
+    expect(result).toHaveLength(0);
+    expect(mockOracleResultCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty array when there are no Locked markets", async () => {
+    mockMarketFindMany.mockResolvedValueOnce([]);
+
+    const feed = makeFeed("BoxRec", makeExternalResult());
+    const result = await pollExternalResultFeeds({ feeds: [feed], db });
+
+    expect(result).toHaveLength(0);
+    expect(mockOracleResultCreate).not.toHaveBeenCalled();
+    expect(feed.fetch).not.toHaveBeenCalled();
+  });
+
+  // ── Skip markets with existing unconfirmed candidate ────────────────────
+
+  it("skips markets that already have an unconfirmed OracleResult row", async () => {
+    const market = makeMarket();
+    mockMarketFindMany.mockResolvedValueOnce([market]);
+    // An unconfirmed candidate already exists
+    mockOracleResultFindUnique.mockResolvedValueOnce({
+      id: "existing-oresult",
+      marketId: market.id,
+      confirmed: false,
+    });
+
+    const feed = makeFeed("BoxRec", makeExternalResult());
+    const result = await pollExternalResultFeeds({ feeds: [feed], db });
+
+    expect(result).toHaveLength(0);
+    expect(feed.fetch).not.toHaveBeenCalled();
+    expect(mockOracleResultCreate).not.toHaveBeenCalled();
+  });
+
+  // ── Source + confidence logged ────────────────────────────────────────────
+
+  it("logs source and confidence for every queued candidate", async () => {
+    const market = makeMarket();
+    mockMarketFindMany.mockResolvedValueOnce([market]);
+    mockOracleResultFindUnique.mockResolvedValueOnce(null);
+    mockOracleResultCreate.mockResolvedValueOnce({ id: "oresult-4", marketId: market.id, confirmed: false });
+
+    const externalResult = makeExternalResult({ source: "https://api.boxrec.com" });
+    const feed = makeFeed("BoxRec", externalResult);
+    await pollExternalResultFeeds({ feeds: [feed], db });
+
+    const loggerInfo = logger.info as jest.Mock;
+    // Find the call that logs the candidate resolution
+    const candidateLog = loggerInfo.mock.calls.find(
+      ([meta]: [Record<string, unknown>]) => meta && meta.oracleResultId === "oresult-4",
+    );
+    expect(candidateLog).toBeDefined();
+    const [meta] = candidateLog;
+    expect(meta.source).toBe("https://api.boxrec.com");
+    expect(typeof meta.confidence).toBe("number");
+    expect(meta.confidence).toBeGreaterThan(0);
+    expect(meta.confidence).toBeLessThanOrEqual(1);
+  });
+
+  it("logs each feed query result (source + found flag)", async () => {
+    const market = makeMarket();
+    mockMarketFindMany.mockResolvedValueOnce([market]);
+    mockOracleResultFindUnique.mockResolvedValueOnce(null);
+    mockOracleResultCreate.mockResolvedValueOnce({ id: "oresult-5", marketId: market.id, confirmed: false });
+
+    const feed = makeFeed("BoxRec", makeExternalResult());
+    await pollExternalResultFeeds({ feeds: [feed], db });
+
+    const loggerInfo = logger.info as jest.Mock;
+    const feedQueryLog = loggerInfo.mock.calls.find(
+      ([meta]: [Record<string, unknown>]) => meta && meta.source === "BoxRec",
+    );
+    expect(feedQueryLog).toBeDefined();
+    expect(feedQueryLog[0].found).toBe(true);
+  });
+
+  // ── Multiple markets ────────────────────────────────────────────────────
+
+  it("queues one candidate per market when multiple markets are pending", async () => {
+    const markets = [
+      makeMarket({ id: "market-1" }),
+      makeMarket({ id: "market-2" }),
+    ];
+    mockMarketFindMany.mockResolvedValueOnce(markets);
+
+    // Both markets have no existing candidate
+    mockOracleResultFindUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    mockOracleResultCreate
+      .mockResolvedValueOnce({ id: "oresult-m1", marketId: "market-1", confirmed: false })
+      .mockResolvedValueOnce({ id: "oresult-m2", marketId: "market-2", confirmed: false });
+
+    const feed: FeedSource = {
+      name: "BoxRec",
+      fetch: jest.fn().mockResolvedValue(makeExternalResult()),
+    };
+
+    const results = await pollExternalResultFeeds({ feeds: [feed], db });
+
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.marketId)).toEqual(["market-1", "market-2"]);
+  });
+
+  // ── Feed errors handled gracefully ───────────────────────────────────────
+
+  it("continues processing other feeds when one feed throws", async () => {
+    const market = makeMarket();
+    mockMarketFindMany.mockResolvedValueOnce([market]);
+    mockOracleResultFindUnique.mockResolvedValueOnce(null);
+    mockOracleResultCreate.mockResolvedValueOnce({ id: "oresult-6", marketId: market.id, confirmed: false });
+
+    const failingFeed: FeedSource = {
+      name: "FailSource",
+      fetch: jest.fn().mockRejectedValue(new Error("Network timeout")),
+    };
+    const workingFeed: FeedSource = {
+      name: "WorkingSource",
+      fetch: jest.fn().mockResolvedValue(makeExternalResult()),
+    };
+
+    const results = await pollExternalResultFeeds({
+      feeds: [failingFeed, workingFeed],
+      db,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].oracleResultId).toBe("oresult-6");
+
+    // Error logged for the failing feed
+    const loggerError = logger.error as jest.Mock;
+    const errorLog = loggerError.mock.calls.find(
+      ([meta]: [Record<string, unknown>]) => meta && String(meta.error).includes("Network timeout"),
+    );
+    expect(errorLog).toBeDefined();
+  });
+
+  it("returns empty array and logs error when ALL feeds throw", async () => {
+    const market = makeMarket();
+    mockMarketFindMany.mockResolvedValueOnce([market]);
+    mockOracleResultFindUnique.mockResolvedValueOnce(null);
+
+    const feed: FeedSource = {
+      name: "FailSource",
+      fetch: jest.fn().mockRejectedValue(new Error("Service unavailable")),
+    };
+
+    const results = await pollExternalResultFeeds({ feeds: [feed], db });
+
+    expect(results).toHaveLength(0);
+    expect(mockOracleResultCreate).not.toHaveBeenCalled();
+  });
+
+  // ── Confidence score calculation ─────────────────────────────────────────
+
+  it("reports confidence of 1.0 when all sources agree", async () => {
+    const market = makeMarket();
+    mockMarketFindMany.mockResolvedValueOnce([market]);
+    mockOracleResultFindUnique.mockResolvedValueOnce(null);
+    mockOracleResultCreate.mockResolvedValueOnce({ id: "oresult-7", marketId: market.id, confirmed: false });
+
+    const feedA = makeFeed("BoxRec", makeExternalResult({ winner: "FighterA" }));
+    const feedB = makeFeed("ESPN", makeExternalResult({ winner: "FighterA" }));
+
+    const results = await pollExternalResultFeeds({
+      feeds: [feedA, feedB],
+      db,
+    });
+
+    expect(results[0].confidence).toBe(1);
+  });
+
+  it("reports confidence of 0.5 when only one of two feeds returns a result", async () => {
+    const market = makeMarket();
+    mockMarketFindMany.mockResolvedValueOnce([market]);
+    mockOracleResultFindUnique.mockResolvedValueOnce(null);
+    mockOracleResultCreate.mockResolvedValueOnce({ id: "oresult-8", marketId: market.id, confirmed: false });
+
+    const feedA = makeFeed("BoxRec", makeExternalResult({ winner: "FighterA" }));
+    const feedB = makeFeed("ESPN", null); // no result
+
+    const results = await pollExternalResultFeeds({
+      feeds: [feedA, feedB],
+      db,
+    });
+
+    expect(results[0].confidence).toBe(0.5);
+  });
+
+  // ── Dependency injection ──────────────────────────────────────────────────
+
+  it("uses the injected db for all DB calls", async () => {
+    mockMarketFindMany.mockResolvedValueOnce([]);
+
+    await pollExternalResultFeeds({ feeds: [], db });
+
+    expect(mockMarketFindMany).toHaveBeenCalled();
+  });
+
+  it("CandidateResolution contains marketId, oracleResultId, source, confidence, result", async () => {
+    const market = makeMarket({ id: "market-xyz" });
+    mockMarketFindMany.mockResolvedValueOnce([market]);
+    mockOracleResultFindUnique.mockResolvedValueOnce(null);
+    mockOracleResultCreate.mockResolvedValueOnce({
+      id: "oresult-xyz",
+      marketId: "market-xyz",
+      confirmed: false,
+    });
+
+    const externalResult = makeExternalResult({
+      source: "https://api.boxrec.com",
+      winner: "FighterB",
+    });
+    const feed = makeFeed("BoxRec", externalResult);
+    const results = await pollExternalResultFeeds({ feeds: [feed], db });
+
+    const candidate: CandidateResolution = results[0];
+    expect(candidate.marketId).toBe("market-xyz");
+    expect(candidate.oracleResultId).toBe("oresult-xyz");
+    expect(candidate.source).toBe("https://api.boxrec.com");
+    expect(candidate.confidence).toBe(1);
+    expect(candidate.result).toEqual(externalResult);
+  });
+});

--- a/backend/src/services/oracle.service.ts
+++ b/backend/src/services/oracle.service.ts
@@ -10,6 +10,7 @@ import {
   nativeToScVal,
   xdr,
 } from "@stellar/stellar-sdk";
+import { logger } from "../logger";
 
 const prisma = new PrismaClient();
 const RPC_URL = process.env.STELLAR_RPC_URL!;
@@ -299,4 +300,285 @@ export async function deleteOracle(id: string) {
     where: { id },
     data: { active: false },
   });
+}
+
+// ─── B-22 / #1080 ──────────────────────────────────────────────────────────
+
+/**
+ * Custom error thrown when a submitter is not the authorized oracle for a market.
+ * Carries the market ID and both addresses so callers can log or surface them.
+ */
+export class OracleAuthorizationError extends Error {
+  constructor(
+    public readonly marketId: string,
+    public readonly expected: string,
+    public readonly actual: string,
+  ) {
+    super(
+      `Oracle authorization failed for market ${marketId}: ` +
+        `expected ${expected}, got ${actual}`,
+    );
+    this.name = "OracleAuthorizationError";
+  }
+}
+
+/**
+ * Confirms that `submitter` is the configured oracle for `market_id`.
+ *
+ * Resolution order:
+ *   1. Look up the market's `oracleAddress` column.
+ *   2. If the address matches `submitter`, authorization is granted.
+ *   3. As a fallback, check whether `submitter` is a registered, active entry
+ *      in the `Oracle` table (for globally-whitelisted oracles).
+ *
+ * The function is fully unit-testable without a live database or Stellar node:
+ * pass a mock PrismaClient via the optional `db` parameter.
+ *
+ * @param market_id  - The BOXMEOUT market UUID to authorize against.
+ * @param submitter  - The Stellar public key (G…) or identifier of the caller.
+ * @param db         - Optional PrismaClient for dependency injection in tests.
+ * @throws {Error}                   If the market does not exist.
+ * @throws {OracleAuthorizationError} If `submitter` is not the market's oracle.
+ */
+export async function verifyOracleAuthorization(
+  market_id: string,
+  submitter: string,
+  db: PrismaClient = prisma,
+): Promise<void> {
+  const market = await db.market.findUnique({ where: { id: market_id } });
+  if (!market) {
+    throw new Error(`Market not found: ${market_id}`);
+  }
+
+  // Direct address match — the most common path.
+  if (market.oracleAddress === submitter) {
+    return;
+  }
+
+  // Fallback: submitter is a globally registered, active oracle.
+  const registeredOracle = await db.oracle.findFirst({
+    where: { address: submitter, active: true },
+  });
+  if (registeredOracle) {
+    return;
+  }
+
+  throw new OracleAuthorizationError(market_id, market.oracleAddress, submitter);
+}
+
+// ─── B-24 / #1082 ──────────────────────────────────────────────────────────
+
+/**
+ * Shape of one whitelisted external feed source.
+ * Injectable so tests can supply a deterministic list.
+ */
+export interface FeedSource {
+  /** Human-readable name used in audit logs (e.g. "BoxRec", "ESPN"). */
+  name: string;
+  /**
+   * Fetch a result for the given market.  Returns `null` if the fight has not
+   * yet been reported by this source.
+   *
+   * The signature mirrors `fetchExternalResult` so the default implementation
+   * can delegate straight to it.
+   */
+  fetch: (market_id: string) => Promise<ExternalFightResult | null>;
+}
+
+/**
+ * A candidate resolution queued by `pollExternalResultFeeds`.
+ * Stored with `confirmed = false`; an admin must call `confirmFightResult` to
+ * trigger on-chain resolution.
+ */
+export interface CandidateResolution {
+  marketId: string;
+  oracleResultId: string;
+  source: string;
+  /** 0–1 confidence score derived from source agreement. */
+  confidence: number;
+  result: ExternalFightResult;
+}
+
+/**
+ * Default feed sources wired to the module-level `fetchExternalResult`.
+ * Override via `options.feeds` in tests or to add more sources.
+ */
+function defaultFeeds(): FeedSource[] {
+  return [
+    {
+      name: "BoxRec",
+      fetch: (market_id) => fetchExternalResult(market_id),
+    },
+  ];
+}
+
+/** Maps an ExternalFightResult winner string to the DB Outcome enum. */
+function mapWinnerToOutcome(winner: ExternalFightResult["winner"]): Outcome {
+  const map: Record<ExternalFightResult["winner"], Outcome> = {
+    FighterA: "FighterA",
+    FighterB: "FighterB",
+    Draw: "Draw",
+    NoContest: "NoContest",
+  };
+  return map[winner];
+}
+
+export interface PollOptions {
+  /** Whitelisted data sources to query. Defaults to BoxRec. */
+  feeds?: FeedSource[];
+  /**
+   * Minimum fraction of sources that must agree for confidence > 0.
+   * Not used to gate submission — only surfaced in the audit log.
+   */
+  db?: PrismaClient;
+}
+
+/**
+ * Polls all whitelisted boxing-result feeds for every Locked market that does
+ * not yet have a confirmed oracle result.  For each market where at least one
+ * source returns a result, a candidate `OracleResult` row is created with
+ * `confirmed = false`.
+ *
+ * IMPORTANT — this function NEVER auto-submits on-chain.  Every candidate
+ * must be reviewed and confirmed by an admin via `confirmFightResult()`.
+ *
+ * Audit trail:
+ *   - Logs each source query (market, source name, result or null).
+ *   - Logs the queued candidate with source + confidence score.
+ *   - Logs any per-source errors without aborting the entire poll.
+ *
+ * @param options.feeds - Override the default feed list (useful in tests).
+ * @param options.db    - Injectable PrismaClient for unit tests.
+ * @returns Array of candidate resolutions that were queued this run.
+ */
+export async function pollExternalResultFeeds(
+  options: PollOptions = {},
+): Promise<CandidateResolution[]> {
+  const db = options.db ?? prisma;
+  const feeds = options.feeds ?? defaultFeeds();
+
+  // Fetch all Locked markets without a confirmed result.
+  const pendingMarkets = await db.market.findMany({
+    where: {
+      status: "Locked",
+      OR: [
+        { oracleResult: null },
+        { oracleResult: { confirmed: false } },
+      ],
+    },
+    orderBy: { scheduledAt: "asc" },
+  });
+
+  logger.info(
+    { count: pendingMarkets.length },
+    "pollExternalResultFeeds: checking markets",
+  );
+
+  const queued: CandidateResolution[] = [];
+
+  for (const market of pendingMarkets) {
+    // Skip markets that already have a pending (unconfirmed) candidate so we
+    // don't create duplicate rows on repeated polls.
+    const existingResult = await db.oracleResult.findUnique({
+      where: { marketId: market.id },
+    });
+    if (existingResult) {
+      logger.debug(
+        { marketId: market.id, oracleResultId: existingResult.id },
+        "pollExternalResultFeeds: skipping market — unconfirmed candidate already exists",
+      );
+      continue;
+    }
+
+    // Query every feed in parallel, capturing both results and errors.
+    const feedResults = await Promise.allSettled(
+      feeds.map(async (feed) => {
+        const result = await feed.fetch(market.id);
+        logger.info(
+          {
+            marketId: market.id,
+            source: feed.name,
+            found: result !== null,
+            winner: result?.winner ?? null,
+            method: result?.method ?? null,
+          },
+          "pollExternalResultFeeds: feed query result",
+        );
+        return { feed, result };
+      }),
+    );
+
+    // Collect successful, non-null results.
+    const hits: Array<{ feed: FeedSource; result: ExternalFightResult }> = [];
+    for (const settled of feedResults) {
+      if (settled.status === "fulfilled" && settled.value.result !== null) {
+        hits.push(settled.value as { feed: FeedSource; result: ExternalFightResult });
+      } else if (settled.status === "rejected") {
+        logger.error(
+          { marketId: market.id, error: String(settled.reason) },
+          "pollExternalResultFeeds: feed query error",
+        );
+      }
+    }
+
+    if (hits.length === 0) {
+      logger.debug(
+        { marketId: market.id },
+        "pollExternalResultFeeds: no result available yet",
+      );
+      continue;
+    }
+
+    // Use the first available result as the candidate (sources are ordered by
+    // priority in the feeds array).  Confidence is the fraction of sources
+    // that returned a result — surfaced in the audit log only.
+    const primary = hits[0];
+    const confidence = hits.length / feeds.length;
+    const outcome = mapWinnerToOutcome(primary.result.winner);
+    const reporter = `poll:${primary.feed.name}`;
+
+    // Queue as unconfirmed — admin MUST call confirmFightResult() to proceed.
+    const oracleResult = await db.oracleResult.create({
+      data: {
+        marketId: market.id,
+        reportedBy: reporter,
+        outcome,
+        source: primary.result.source,
+        confirmed: false, // Explicit: never auto-confirms.
+      },
+    });
+
+    const candidate: CandidateResolution = {
+      marketId: market.id,
+      oracleResultId: oracleResult.id,
+      source: primary.result.source,
+      confidence,
+      result: primary.result,
+    };
+
+    // Audit log — source + confidence for every queued candidate.
+    logger.info(
+      {
+        marketId: market.id,
+        oracleResultId: oracleResult.id,
+        source: primary.result.source,
+        confidence,
+        outcome,
+        winner: primary.result.winner,
+        method: primary.result.method,
+        round: primary.result.round,
+        reportedAt: primary.result.reportedAt,
+      },
+      "pollExternalResultFeeds: candidate resolution queued — awaiting admin confirmation",
+    );
+
+    queued.push(candidate);
+  }
+
+  logger.info(
+    { queued: queued.length },
+    "pollExternalResultFeeds: poll complete",
+  );
+
+  return queued;
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -13,14 +13,10 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "types": ["jest", "node"]
-  },
-  "include": ["src/**/*", "__tests__/**/*"],
-  "exclude": ["node_modules", "dist"]
     "types": ["jest", "node"],
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "__tests__"]
+  "include": ["src/**/*", "__tests__/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
…ultFeeds (#1080, #1082)

B-22 / #1080 — verifyOracleAuthorization
- Check submitter matches market oracleAddress; fall back to global Oracle table
- Throw typed OracleAuthorizationError on mismatch with expected/actual addresses
- Accept injectable PrismaClient for unit testing without live DB

B-24 / #1082 — pollExternalResultFeeds
- Poll whitelisted FeedSource[] for all Locked markets lacking a confirmed result
- Create OracleResult with confirmed=false; never auto-submits on-chain
- Log source + confidence score for full audit trail
- Injectable feeds and db for unit testing without live network

Tests: 23 unit tests, all passing (oracle.service.b22-b24.test.ts)

Fix: repair duplicate-key syntax errors in jest.config.ts and tsconfig.json
closes #1080 
closes #1082 