### PR TITLE
fix(F-38): responsive layout pass — no horizontal scroll at 375px

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -8,7 +8,12 @@
   box-sizing: border-box;
 }
 
+html {
+  overflow-x: hidden;
+}
+
 body {
+  overflow-x: hidden;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { Navbar } from '@/components/Navbar';
 import { ToastProvider } from '@/components/ToastProvider';
 import '@/app/globals.css';
 
@@ -16,7 +17,10 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <ToastProvider>
-          {children}
+          <Navbar />
+          <main className="min-w-0 overflow-x-hidden">
+            {children}
+          </main>
         </ToastProvider>
       </body>
     </html>

--- a/frontend/app/portfolio/page.tsx
+++ b/frontend/app/portfolio/page.tsx
@@ -11,7 +11,7 @@ export default function PortfolioPage(): JSX.Element {
 
   if (!address) {
     return (
-      <div className="text-center py-20 text-gray-400">
+      <div className="container mx-auto px-4 py-8 text-center text-gray-400">
         <p className="text-4xl mb-4">👛</p>
         <p className="mb-6 text-lg">Connect your wallet to view your portfolio.</p>
         <WalletConnectButton onConnected={connect} />
@@ -20,7 +20,7 @@ export default function PortfolioPage(): JSX.Element {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="container mx-auto px-4 py-8 space-y-6">
       <h1 className="text-2xl font-bold text-white">My Portfolio</h1>
 
       {isLoading ? (

--- a/frontend/components/HomePageContent.tsx
+++ b/frontend/components/HomePageContent.tsx
@@ -40,22 +40,24 @@ export function HomePageContent({ initialMarkets }: HomePageContentProps): JSX.E
       </section>
 
       {/* Tab bar */}
-      <div className="flex gap-1 rounded-lg bg-gray-800 p-1 w-fit mb-6" role="tablist">
-        {TABS.map((t) => (
-          <button
-            key={t}
-            role="tab"
-            aria-selected={tab === t}
-            onClick={() => setTab(t)}
-            className={`px-5 py-2 rounded-md text-sm font-medium transition-colors ${
-              tab === t
-                ? "bg-amber-500 text-black shadow-sm"
-                : "text-gray-400 hover:text-white"
-            }`}
-          >
-            {t}
-          </button>
-        ))}
+      <div className="overflow-x-auto mb-6">
+        <div className="flex gap-1 rounded-lg bg-gray-800 p-1 w-max min-w-full sm:min-w-0" role="tablist">
+          {TABS.map((t) => (
+            <button
+              key={t}
+              role="tab"
+              aria-selected={tab === t}
+              onClick={() => setTab(t)}
+              className={`flex-1 sm:flex-none px-5 py-2 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                tab === t
+                  ? "bg-amber-500 text-black shadow-sm"
+                  : "text-gray-400 hover:text-white"
+              }`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
       </div>
 
       <MarketList markets={filtered} isLoading={false} />

--- a/frontend/components/MarketFilterBar.tsx
+++ b/frontend/components/MarketFilterBar.tsx
@@ -20,26 +20,29 @@ export function MarketFilterBar({
 }: MarketFilterBarProps): JSX.Element {
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-6">
-      <div className="flex gap-1 rounded-lg bg-gray-100 p-1">
-        {STATUS_TABS.map((tab) => (
-          <button
-            key={tab}
-            onClick={() => onStatusChange(tab)}
-            className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
-              statusTab === tab
-                ? "bg-white text-gray-900 shadow-sm"
-                : "text-gray-600 hover:text-gray-900"
-            }`}
-          >
-            {tab}
-          </button>
-        ))}
+      {/* Scrollable tab strip — prevents overflow at 375 px */}
+      <div className="overflow-x-auto">
+        <div className="flex gap-1 rounded-lg bg-gray-100 p-1 w-max min-w-full sm:min-w-0">
+          {STATUS_TABS.map((tab) => (
+            <button
+              key={tab}
+              onClick={() => onStatusChange(tab)}
+              className={`flex-1 sm:flex-none px-4 py-1.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
+                statusTab === tab
+                  ? "bg-white text-gray-900 shadow-sm"
+                  : "text-gray-600 hover:text-gray-900"
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
       </div>
 
       <select
         value={weightClass}
         onChange={(e) => onWeightClassChange(e.target.value)}
-        className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        className="w-full sm:w-auto rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
       >
         <option value="">All Weight Classes</option>
         {weightClasses.map((wc) => (

--- a/frontend/components/MarketOddsBar.tsx
+++ b/frontend/components/MarketOddsBar.tsx
@@ -12,9 +12,9 @@ export function MarketOddsBar({ poolA, poolB, fighterAName, fighterBName }: Mark
 
   return (
     <div className="w-full">
-      <div className="flex justify-between text-xs text-gray-400 mb-1">
-        <span>{fighterAName} {pctA}%</span>
-        <span>{pctB}% {fighterBName}</span>
+      <div className="flex justify-between text-xs text-gray-400 mb-1 gap-2">
+        <span className="min-w-0 truncate">{fighterAName} {pctA}%</span>
+        <span className="min-w-0 truncate text-right">{pctB}% {fighterBName}</span>
       </div>
       <div className="flex rounded-full overflow-hidden h-3">
         <div className="bg-blue-500 transition-all" style={{ width: `${pctA}%` }} />


### PR DESCRIPTION
## Summary

Closes #1136
Closes #1135 
Fixes all pages at mobile/tablet/desktop breakpoints so there is no horizontal scroll or overlapping elements at 375px width.

## Changes

### `app/globals.css`
- Added `overflow-x: hidden` to both `html` and `body` as a safety net against any element that slips past its container bounds.

### `app/layout.tsx`
- Imported and rendered `<Navbar>` in the root layout so every page shares the navigation bar.
- Wrapped `{children}` in a `<main>` with `min-w-0 overflow-x-hidden` to contain any child overflow.

### `components/MarketFilterBar.tsx`
- Wrapped the 4-tab strip in `overflow-x-auto` + `w-max` so the pill buttons never break out of the 375px viewport; they scroll horizontally within their container if needed.
- Added `whitespace-nowrap` to each button to prevent awkward line breaks.
- Made the weight-class `<select>` full-width on mobile (`w-full sm:w-auto`).

### `components/HomePageContent.tsx`
- Applied the same `overflow-x-auto` + `w-max` treatment to the Active/Upcoming/Resolved tab bar.

### `components/MarketOddsBar.tsx`
- Added `min-w-0 truncate` to both fighter-name spans so long names are clipped instead of pushing the odds bar wider than the viewport.

### `app/portfolio/page.tsx`
- Added `container mx-auto px-4` wrapper for consistent side padding on all breakpoints and to prevent the content from bleeding edge-to-edge.

## Testing

Verified at 375px, 768px, and 1280px viewport widths against all pages: Home, Markets detail, Create Market, and Portfolio.