### PR TITLE
ci(frontend): add GitHub Actions workflow for lint, typecheck, tests, and build

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,61 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
+
+concurrency:
+  group: frontend-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Lint / Type-check / Test / Build
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ── Lint ────────────────────────────────────────────────────────────────
+      - name: Lint
+        run: npm run lint
+
+      # ── Type-check ──────────────────────────────────────────────────────────
+      - name: Type-check
+        run: npm run type-check
+
+      # ── Unit tests ──────────────────────────────────────────────────────────
+      - name: Test
+        run: npm test -- --ci --coverage --passWithNoTests
+        env:
+          # Stub env vars so Next.js doesn't complain during test runs
+          NEXT_PUBLIC_API_URL: "http://localhost:3001"
+          NEXT_PUBLIC_STELLAR_NETWORK: "testnet"
+          NEXT_PUBLIC_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org"
+          NEXT_PUBLIC_MARKET_FACTORY_CONTRACT_ID: "CDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+      # ── Build ────────────────────────────────────────────────────────────────
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_API_URL: "http://localhost:3001"
+          NEXT_PUBLIC_STELLAR_NETWORK: "testnet"
+          NEXT_PUBLIC_SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org"
+          NEXT_PUBLIC_MARKET_FACTORY_CONTRACT_ID: "CDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/frontend-ci.yml` — a GitHub Actions workflow that runs on every PR that touches `/frontend`.

**Steps in the workflow:**

| Step | Command |
|---|---|
| Install | `npm ci` with `npm` cache keyed on `frontend/package-lock.json` |
| Lint | `npm run lint` (Next.js ESLint / core-web-vitals) |
| Type-check | `npm run type-check` (`tsc --noEmit`, strict mode) |
| Test | `npm test -- --ci --coverage --passWithNoTests` (Jest + jsdom) |
| Build | `npm run build` (Next.js production build) |

**Trigger:** `pull_request` with a path filter on `frontend/**` and the workflow file itself — PRs that don't touch the frontend are skipped entirely.

**Concurrency:** duplicate runs on the same branch are cancelled automatically so only the latest commit runs.

**Env vars:** stub `NEXT_PUBLIC_*` values are injected for the test and build steps so Next.js doesn't error on missing variables in CI.

Closes #1137