### PR TITLE
feat(backend): prisma singleton + updateMarketStatus service (#880 #884)

### DIFF
--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,3 +1,23 @@
 import { PrismaClient } from "@prisma/client";
 
-export const db = new PrismaClient();
+// Singleton guard: in development, ts-node-dev hot-reloads modules which would
+// create a new PrismaClient on every reload, exhausting the connection pool.
+// Storing the instance on globalThis ensures only one client exists per process.
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __prisma: PrismaClient | undefined;
+}
+
+export const db: PrismaClient =
+  globalThis.__prisma ??
+  new PrismaClient({
+    log:
+      process.env.NODE_ENV === "development"
+        ? ["query", "warn", "error"]
+        : ["warn", "error"],
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalThis.__prisma = db;
+}

--- a/backend/src/lib/db.ts
+++ b/backend/src/lib/db.ts
@@ -1,5 +1,3 @@
-import { PrismaClient } from "@prisma/client";
-
-const db = new PrismaClient();
-
-export default db;
+// Re-export the canonical singleton from src/db.ts so legacy imports don't
+// create a second PrismaClient instance.
+export { db as default } from "../db";

--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -1,5 +1,3 @@
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
-
-export default prisma;
+// Re-export the canonical singleton from src/db.ts so legacy imports don't
+// create a second PrismaClient instance.
+export { db as default } from "../db";

--- a/backend/src/services/market.service.ts
+++ b/backend/src/services/market.service.ts
@@ -94,7 +94,7 @@ export async function getAllMarkets(
   }
 
   const page = pagination?.page ?? 1;
-  const limit = pagination?.limit ?? 20;
+  const limit = Math.min(pagination?.pageSize ?? 20, MAX_PAGE_SIZE);
 
   return db.market.findMany({
     where,
@@ -110,26 +110,6 @@ export async function getAllMarkets(
  */
 export async function getMarketById(market_id: string): Promise<Market | null> {
   return db.market.findUnique({ where: { id: market_id } });
-}
-
-export async function createMarketRecord(marketData: CreateMarketDTO): Promise<Market> {
-  return db.market.upsert({
-    where: { id: txHash },
-    update: {},
-    create: {
-      id: txHash,
-      contractAddress: marketData.contractAddress ?? "",
-      fighterA: marketData.fighterA,
-      fighterB: marketData.fighterB,
-      scheduledAt: marketData.scheduledAt,
-      bettingEndsAt: marketData.bettingEndsAt,
-      createdAt: new Date(),
-      createdBy: marketData.createdBy,
-      oracleAddress: marketData.oracleAddress ?? "",
-      txHash,
-      status: "Open",
-    },
-  });
 }
 
 /**
@@ -154,7 +134,7 @@ export async function createMarketRecord(
 
       if (optimistic) {
         // Atomically delete the optimistic row and create the real one
-        await tx.market.delete({ where: { id: marketData.txHash! } });
+        await tx.market.delete({ where: { id: marketData.txHash } });
         const market = await tx.market.create({
           data: {
             id: marketData.id,
@@ -256,9 +236,7 @@ export async function reconcileMarketFromChain(
   }
 
   if (!simResult.result?.retval) {
-    throw new Error(
-      `Empty simulation result for market ${marketId}`
-    );
+    throw new Error(`Empty simulation result for market ${marketId}`);
   }
 
   // Convert the ScVal return value to a native JS object.
@@ -316,6 +294,13 @@ export async function reconcileMarketFromChain(
   return updated;
 }
 
+/**
+ * Updates the status of a market and optionally its outcome.
+ * Sets resolvedAt when transitioning to Resolved.
+ *
+ * Covers all MarketStatus transitions:
+ *   Open → Locked → Resolved | Cancelled | Disputed
+ */
 export async function updateMarketStatus(
   market_id: string,
   status: MarketStatus,
@@ -326,7 +311,7 @@ export async function updateMarketStatus(
     data: {
       status,
       ...(outcome !== undefined && { outcome }),
-      ...(status === "Resolved" && { resolvedAt: new Date() }),
+      ...(status === MarketStatus.Resolved && { resolvedAt: new Date() }),
     },
   });
 }
@@ -383,7 +368,7 @@ export async function getMarketLeaderboard(
   pagination?: Pagination
 ): Promise<LeaderboardEntry[]> {
   const page = pagination?.page ?? 1;
-  const limit = pagination?.limit ?? 20;
+  const limit = Math.min(pagination?.pageSize ?? 20, MAX_PAGE_SIZE);
   const skip = (page - 1) * limit;
 
   const bets = await db.bet.findMany({
@@ -406,7 +391,9 @@ export async function getMarketLeaderboard(
   // Sort by totalStaked desc, apply pagination
   const sorted = Array.from(bettorMap.entries())
     .map(([bettor, stats]) => ({ bettor, ...stats }))
-    .sort((a, b) => (b.totalStaked > a.totalStaked ? 1 : b.totalStaked < a.totalStaked ? -1 : 0));
+    .sort((a, b) =>
+      b.totalStaked > a.totalStaked ? 1 : b.totalStaked < a.totalStaked ? -1 : 0
+    );
 
   return sorted.slice(skip, skip + limit);
 }
@@ -421,7 +408,7 @@ export async function resolveMarket(
   source: string,
   admin: string
 ): Promise<Market> {
-  const market = await prisma.market.update({
+  const market = await db.market.update({
     where: { id: marketId },
     data: {
       status: MarketStatus.Resolved,
@@ -430,7 +417,7 @@ export async function resolveMarket(
     },
   });
 
-  await prisma.adminLog.create({
+  await db.adminLog.create({
     data: {
       action: "RESOLVE_MARKET",
       actor: admin,
@@ -451,7 +438,7 @@ export async function cancelMarket(
   admin: string,
   reason?: string
 ): Promise<Market> {
-  const market = await prisma.market.update({
+  const market = await db.market.update({
     where: { id: marketId },
     data: {
       status: MarketStatus.Cancelled,
@@ -459,7 +446,7 @@ export async function cancelMarket(
     },
   });
 
-  await prisma.adminLog.create({
+  await db.adminLog.create({
     data: {
       action: "CANCEL_MARKET",
       actor: admin,
@@ -481,7 +468,7 @@ export async function resolveMarketDispute(
   admin: string,
   resolution?: string
 ): Promise<Market> {
-  const market = await prisma.market.update({
+  const market = await db.market.update({
     where: { id: marketId },
     data: {
       status: MarketStatus.Resolved,
@@ -490,7 +477,7 @@ export async function resolveMarketDispute(
     },
   });
 
-  await prisma.adminLog.create({
+  await db.adminLog.create({
     data: {
       action: "RESOLVE_DISPUTE",
       actor: admin,


### PR DESCRIPTION

---

## Changes

### Issue #880 — Prisma Singleton (`src/db.ts`)

**Problem:** \`src/db.ts\` exported a bare \`new PrismaClient()\` with no singleton guard. In development, \`ts-node-dev\` hot-reloads modules on every file save, which would instantiate a new \`PrismaClient\` on each reload — exhausting the PostgreSQL connection pool quickly.

Additionally, \`src/lib/prisma.ts\` and \`src/lib/db.ts\` each created their own independent \`PrismaClient\` instances, meaning the app could silently run with 3 separate connection pools.

**Fix:**
- Rewrote \`src/db.ts\` to use a \`globalThis.__prisma\` guard. In non-production environments, the instance is stored on \`globalThis\` so hot-reloads reuse the existing connection instead of spawning a new one. Production always creates a fresh instance on startup.
- Configured \`PrismaClient\` log levels: \`query + warn + error\` in development, \`warn + error\` in production.
- Consolidated \`src/lib/prisma.ts\` and \`src/lib/db.ts\` to re-export from the canonical \`src/db.ts\` singleton rather than each owning their own client.

\`\`\`ts
// src/db.ts
export const db: PrismaClient =
  globalThis.__prisma ?? new PrismaClient({ log: [...] });

if (process.env.NODE_ENV !== 'production') {
  globalThis.__prisma = db;
}
\`\`\`

**Acceptance criteria met:**
- \`import { db } from './db'\` works in any service file — all existing services (\`market.service.ts\`, \`bet.service.ts\`, \`resolution.service.ts\`) already use this import and continue to work unchanged.
- \`npm run db:migrate\` and \`npm run db:generate\` scripts were already wired correctly in \`package.json\`.
- Prisma schema was already complete and correct with all models, enums, and relations.

---

### Issue #884 — \`updateMarketStatus()\` (`src/services/market.service.ts`)

**Problem:** The service file had several bugs that would cause runtime crashes:

1. **Duplicate \`createMarketRecord\` declaration** — A broken first version of the function (referencing an undefined \`txHash\` variable) was left above the correct transactional implementation, causing a TypeScript compile error.
2. **Undefined \`prisma\` variable** — \`resolveMarket()\`, \`cancelMarket()\`, and \`resolveMarketDispute()\` all called \`prisma.market.update()\` and \`prisma.adminLog.create()\`, but \`prisma\` was never imported or defined. These functions would throw \`ReferenceError: prisma is not defined\` at runtime.
3. **\`pagination?.limit\` mismatch** — \`getAllMarkets()\` and \`getMarketLeaderboard()\` accessed \`pagination?.limit\` but the \`Pagination\` interface defines the field as \`pageSize\`, causing silent \`undefined\` fallbacks on every paginated call.
4. **String literal status check** — \`updateMarketStatus()\` used the string \`'Resolved'\` for the \`resolvedAt\` guard instead of the \`MarketStatus.Resolved\` enum value.

**Fix:**
- Removed the duplicate broken \`createMarketRecord\` declaration entirely.
- Replaced all \`prisma.*\` calls with \`db.*\` throughout \`resolveMarket\`, \`cancelMarket\`, and \`resolveMarketDispute\`.
- Fixed \`pagination?.limit\` → \`pagination?.pageSize\` in both \`getAllMarkets\` and \`getMarketLeaderboard\`, and capped the limit at \`MAX_PAGE_SIZE\`.
- Hardened the \`resolvedAt\` condition in \`updateMarketStatus\` to use \`MarketStatus.Resolved\` enum value.

\`\`\`ts
export async function updateMarketStatus(
  market_id: string,
  status: MarketStatus,
  outcome?: Outcome
): Promise<Market> {
  return db.market.update({
    where: { id: market_id },
    data: {
      status,
      ...(outcome !== undefined && { outcome }),
      ...(status === MarketStatus.Resolved && { resolvedAt: new Date() }),
    },
  });
}
\`\`\`

**Acceptance criteria met:**
- Status updated correctly for all \`MarketStatus\` values (Open, Locked, Resolved, Cancelled, Disputed).
- \`resolvedAt\` is set precisely when \`status === MarketStatus.Resolved\`.
- \`outcome\` is stored when provided, omitted when not.
- \`resolveMarket\`, \`cancelMarket\`, and \`resolveMarketDispute\` now correctly call \`db\` and will no longer throw at runtime.

---

## Files Changed

| File | Change |
|------|--------|
| \`backend/src/db.ts\` | Rewritten — proper singleton with \`globalThis\` guard and log config |
| \`backend/src/lib/prisma.ts\` | Consolidated — re-exports singleton from \`../db\` |
| \`backend/src/lib/db.ts\` | Consolidated — re-exports singleton from \`../db\` |
| \`backend/src/services/market.service.ts\` | Fixed duplicate declaration, \`prisma\` → \`db\`, pagination field, enum guard |" --base main --head feat/880-884-prisma-singleton-update-market-status

closes #880 
closes #884 