### PR TITLE
Feat/events 1047 1048 1049 1050

### DIFF
--- a/contracts/market/src/lib.rs
+++ b/contracts/market/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 use shared::types::{Bet, BetSide, Fighter, Market, MarketStatus, Outcome, ProtocolConfig};
+use shared::events;
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, Address, Bytes, Env, String, Symbol, Vec,
 };
@@ -44,17 +45,6 @@ pub enum DataKey {
     Claimed(Bytes),
     DisputeRaised,
     DisputeReason,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, PartialEq)]
-pub struct BetPlacedEvent {
-    pub bet_id:    Bytes,
-    pub market_id: Bytes,
-    pub bettor:    Address,
-    pub side:      BetSide,
-    pub amount:    i128,
-    pub placed_at: u64,
 }
 
 #[contract]
@@ -220,37 +210,27 @@ impl MarketContract {
         market.total_pool = market.total_pool.checked_add(amount).expect("total_pool overflow");
 
         let bet_count: u64 = env.storage().persistent()
-            .get(&Symbol::new(&env, "BET_CNT"))
-            .unwrap_or(0u64);
-        let new_count = bet_count + 1;
-        env.storage().persistent().set(&Symbol::new(&env, "BET_CNT"), &new_count);
-        let mut id_bytes = [0u8; 32];
-        id_bytes[..8].copy_from_slice(&new_count.to_be_bytes());
-        let bet_id = Bytes::from_array(&env, &id_bytes);
-        let bet_count: u64 = env
-            .storage()
-            .persistent()
             .get(&Symbol::new(&env, "BET_COUNT"))
             .unwrap_or(0u64);
         let new_count = bet_count + 1;
+        env.storage().persistent().set(&Symbol::new(&env, "BET_COUNT"), &new_count);
+
         let mut id_bytes = [0u8; 32];
         id_bytes[..8].copy_from_slice(&new_count.to_be_bytes());
         let bet_id = Bytes::from_array(&env, &id_bytes);
-        env.storage()
-            .persistent()
-            .set(&Symbol::new(&env, "BET_COUNT"), &new_count);
 
+        let placed_at = env.ledger().timestamp();
         let bet = Bet {
             bet_id: bet_id.clone(),
             market_id: market.market_id.clone(),
             bettor: bettor.clone(),
             side: side.clone(),
             amount,
-            placed_at: env.ledger().timestamp(),
+            placed_at,
             claimed: false,
         };
         env.storage().persistent().set(&DataKey::Bet(bet_id.clone()), &bet);
-        env.storage().persistent().set(&DataKey::MarketInfo, &market);
+        Self::write_market(&env, &market);
 
         let mut addr_bets: Vec<Bytes> = env.storage().persistent()
             .get(&DataKey::BetsByAddr(bettor.clone()))
@@ -258,35 +238,28 @@ impl MarketContract {
         addr_bets.push_back(bet_id.clone());
         env.storage().persistent().set(&DataKey::BetsByAddr(bettor.clone()), &addr_bets);
 
-        env.events().publish(
-            (symbol_short!("bet_placed"),),
-        env.storage()
-            .persistent()
-            .set(&DataKey::Bet(bet_id.clone()), &bet);
+        // Emit bet_placed event with market_id, bettor, side, and amount
+        let market_id_u64 = u64::from_le_bytes([
+            market.market_id.as_ref()[0],
+            market.market_id.as_ref()[1],
+            market.market_id.as_ref()[2],
+            market.market_id.as_ref()[3],
+            market.market_id.as_ref()[4],
+            market.market_id.as_ref()[5],
+            market.market_id.as_ref()[6],
+            market.market_id.as_ref()[7],
+        ]);
 
-        let mut bets: Vec<Bytes> = env
-            .storage()
-            .persistent()
-            .get(&DataKey::BetsByAddr(bettor.clone()))
-            .unwrap_or(Vec::new(&env));
-        bets.push_back(bet_id.clone());
-        env.storage()
-            .persistent()
-            .set(&DataKey::BetsByAddr(bettor.clone()), &bets);
-
-        Self::write_market(&env, &market);
-
-        env.events().publish(
-            (Symbol::new(&env, "bet_placed"),),
-            BetPlacedEvent {
-                bet_id: bet_id.clone(),
-                market_id: market.market_id.clone(),
-                bettor,
-                side,
-                amount,
-                placed_at: env.ledger().timestamp(),
-            },
-        );
+        use shared::types::BetRecord;
+        let bet_record = BetRecord {
+            bettor: bettor.clone(),
+            market_id: market_id_u64,
+            side: side.clone(),
+            amount,
+            placed_at,
+            claimed: false,
+        };
+        events::emit_bet_placed(&env, market_id_u64, bet_record);
 
         bet_id
     }
@@ -390,12 +363,21 @@ impl MarketContract {
             _ => MarketStatus::Resolved,
         };
         market.outcome = Some(outcome.clone());
+        let resolution_time = env.ledger().timestamp();
         env.storage().persistent().set(&DataKey::MarketInfo, &market);
 
-        env.events().publish(
-            (symbol_short!("resolved"),),
-            (market.market_id, outcome, env.ledger().timestamp()),
-        );
+        // Emit market_resolved event with market_id, outcome, and resolution_time
+        let market_id_u64 = u64::from_le_bytes([
+            market.market_id.as_ref()[0],
+            market.market_id.as_ref()[1],
+            market.market_id.as_ref()[2],
+            market.market_id.as_ref()[3],
+            market.market_id.as_ref()[4],
+            market.market_id.as_ref()[5],
+            market.market_id.as_ref()[6],
+            market.market_id.as_ref()[7],
+        ]);
+        events::emit_market_resolved(&env, market_id_u64, outcome, resolution_time);
     }
 
     /// Allows a winning bettor to claim their proportional share of the pool.
@@ -481,10 +463,27 @@ impl MarketContract {
         // Mark claimed BEFORE any transfer (re-entrancy guard).
         env.storage().persistent().set(&DataKey::Claimed(bet_id.clone()), &true);
 
-        env.events().publish(
-            (symbol_short!("claimed"),),
-            (bettor, bet_id, payout),
-        );
+        // Emit winnings_claimed event with market_id, claimant, and amount (payout after fee)
+        let market_id_u64 = u64::from_le_bytes([
+            market.market_id.as_ref()[0],
+            market.market_id.as_ref()[1],
+            market.market_id.as_ref()[2],
+            market.market_id.as_ref()[3],
+            market.market_id.as_ref()[4],
+            market.market_id.as_ref()[5],
+            market.market_id.as_ref()[6],
+            market.market_id.as_ref()[7],
+        ]);
+
+        // Create ClaimReceipt for event emission
+        use shared::types::ClaimReceipt;
+        let receipt = ClaimReceipt {
+            bet_id: bet_id.clone(),
+            bettor: bettor.clone(),
+            payout,
+            claimed_at: env.ledger().timestamp(),
+        };
+        events::emit_winnings_claimed(&env, market_id_u64, receipt);
 
         payout
     }
@@ -620,14 +619,31 @@ impl MarketContract {
         market.status = MarketStatus::Disputed;
         Self::write_market(&env, &market);
 
+        // Cap reason length to prevent storage abuse (max 256 bytes)
+        let max_reason_len = 256;
+        if reason.len() > max_reason_len {
+            panic!("dispute reason exceeds maximum length");
+        }
+
         // Store dispute reason
         env.storage().persistent().set(&DataKey::DisputeRaised, &true);
         env.storage().persistent().set(&DataKey::DisputeReason, &reason);
 
-        env.events().publish(
-            (Symbol::new(&env, "DisputeRaised"),),
-            (market.market_id.clone(), bettor.clone(), reason),
-        );
+        // Convert Bytes to String for event emission
+        let reason_str = String::from_bytes(&env, &reason);
+
+        // Emit resolution_disputed event with market_id, disputer, and reason
+        let market_id_u64 = u64::from_le_bytes([
+            market.market_id.as_ref()[0],
+            market.market_id.as_ref()[1],
+            market.market_id.as_ref()[2],
+            market.market_id.as_ref()[3],
+            market.market_id.as_ref()[4],
+            market.market_id.as_ref()[5],
+            market.market_id.as_ref()[6],
+            market.market_id.as_ref()[7],
+        ]);
+        events::emit_resolution_disputed(&env, market_id_u64, bettor.clone(), reason_str);
     }
 
     /// Settles a disputed market with a final admin-override outcome.

--- a/contracts/shared/src/events.rs
+++ b/contracts/shared/src/events.rs
@@ -28,10 +28,10 @@ pub fn emit_market_locked(env: &Env, market_id: u64) {
 /// Emits a `market_resolved` event when an oracle submits a final outcome.
 ///
 /// Topics: `(Symbol("market_resolved"), market_id)`
-/// Data:   `(outcome, oracle_address)`
-pub fn emit_market_resolved(env: &Env, market_id: u64, outcome: Outcome, oracle_address: Address) {
+/// Data:   `(outcome, resolution_time)`
+pub fn emit_market_resolved(env: &Env, market_id: u64, outcome: Outcome, resolution_time: u64) {
     let topics = (Symbol::new(env, "market_resolved"), market_id);
-    env.events().publish(topics, (outcome, oracle_address));
+    env.events().publish(topics, (outcome, resolution_time));
 }
 
 /// Emits a `bet_placed` event when a bettor places a bet.
@@ -77,6 +77,15 @@ pub fn emit_market_cancelled(env: &Env, market_id: u64, reason: String) {
 pub fn emit_market_disputed(env: &Env, market_id: u64, reason: String) {
     let topics = (Symbol::new(env, "market_disputed"), market_id);
     env.events().publish(topics, reason);
+}
+
+/// Emits a `resolution_disputed` event when a resolution is disputed.
+///
+/// Topics: `(Symbol("resolution_disputed"), market_id)`
+/// Data:   `(disputer, reason)`
+pub fn emit_resolution_disputed(env: &Env, market_id: u64, disputer: Address, reason: String) {
+    let topics = (Symbol::new(env, "resolution_disputed"), market_id);
+    env.events().publish(topics, (disputer, reason));
 }
 
 /// Emits a `dispute_resolved` event when an admin finalises a disputed outcome.
@@ -241,15 +250,15 @@ mod tests {
     #[test]
     fn test_emit_market_resolved() {
         let (env, id) = env();
-        let oracle = addr(&env);
-        env.as_contract(&id, || { emit_market_resolved(&env, 3, Outcome::FighterA, oracle.clone()); });
+        let resolution_time = 1_000_000u64;
+        env.as_contract(&id, || { emit_market_resolved(&env, 3, Outcome::FighterA, resolution_time); });
 
         let ev = sole_event!(env);
         assert_eq!(topic_sym!(env, ev), Symbol::new(&env, "market_resolved"));
-        let (ev_outcome, ev_oracle): (Outcome, Address) =
+        let (ev_outcome, ev_time): (Outcome, u64) =
             TryFromVal::try_from_val(&env, &ev.2).unwrap();
         assert_eq!(ev_outcome, Outcome::FighterA);
-        assert_eq!(ev_oracle, oracle);
+        assert_eq!(ev_time, resolution_time);
     }
 
     // ── bet_placed ───────────────────────────────────────────────────────────
@@ -437,6 +446,24 @@ mod tests {
             TryFromVal::try_from_val(&env, &ev.2).unwrap();
         assert_eq!(ev_param, str(&env, "fee_bps"));
         assert_eq!(ev_value, 300_i128);
+    }
+
+    // ── resolution_disputed ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_emit_resolution_disputed() {
+        let (env, id) = env();
+        let disputer = addr(&env);
+        env.as_contract(&id, || { emit_resolution_disputed(&env, 11, disputer.clone(), str(&env, "oracle_error")); });
+
+        let ev = sole_event!(env);
+        assert_eq!(topic_sym!(env, ev), Symbol::new(&env, "resolution_disputed"));
+        let topic_id: u64 = u64::try_from_val(&env, &ev.1.get(1).unwrap()).unwrap();
+        assert_eq!(topic_id, 11_u64);
+        let (ev_disputer, ev_reason): (Address, soroban_sdk::String) =
+            TryFromVal::try_from_val(&env, &ev.2).unwrap();
+        assert_eq!(ev_disputer, disputer);
+        assert_eq!(ev_reason, str(&env, "oracle_error"));
     }
 
     // ── conflicting_oracle_report ─────────────────────────────────────────────

--- a/contracts/shared/src/types.rs
+++ b/contracts/shared/src/types.rs
@@ -73,6 +73,17 @@ pub struct Bet {
 
 #[contracttype]
 #[derive(Clone, Debug)]
+pub struct BetRecord {
+    pub bettor:    Address,
+    pub market_id: u64,
+    pub side:      BetSide,
+    pub amount:    i128,
+    pub placed_at: u64,
+    pub claimed:   bool,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
 pub struct ClaimReceipt {
     pub bet_id:     Bytes,
     pub bettor:     Address,


### PR DESCRIPTION
 ## Summary

  Implement event emissions for market betting lifecycle.

  - **#1047**: Emit `bet_placed` event with market_id, bettor, side, and amount
  - **#1048**: Emit `market_resolved` event with market_id, outcome, and resolution_time
  - **#1049**: Emit `resolution_disputed` event with market_id, disputer, and reason (capped at 256 bytes)
  - **#1050**: Emit `winnings_claimed` event with market_id, claimant, and amount post-fee

  All events use centralized shared events module for consistency.

  Closes #1047
  Closes #1048
  Closes #1049
  Closes #1050